### PR TITLE
Fix Image Cache issues

### DIFF
--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -20,13 +20,12 @@
 #import "RCTNetworking.h"
 #import "RCTUtils.h"
 
-static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 1048576; // 1MB
+static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 1048576 * 4; // 4MB
 
 static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat scale,
                                      RCTResizeMode resizeMode, NSString *responseDate)
 {
-    return [NSString stringWithFormat:@"%@|%g|%g|%g|%zd|%@",
-            imageTag, size.width, size.height, scale, resizeMode, responseDate];
+    return [NSString stringWithFormat:@"%@", imageTag];
 }
 
 @implementation RCTImageCache
@@ -38,7 +37,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
 - (instancetype)init
 {
   _decodedImageCache = [NSCache new];
-  _decodedImageCache.totalCostLimit = 5 * 1024 * 1024; // 5MB
+  _decodedImageCache.totalCostLimit = 32 * 1024 * 1024; // 32MB
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(clearCache)

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -372,6 +372,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
     } else {
       // Use networking module to load image
       cancelLoad = [strongSelf _loadURLRequest:request
+                                          size:size
+                                         scale:scale
+                                    resizeMode:resizeMode
                                  progressBlock:progressHandler
                                completionBlock:completionHandler];
     }
@@ -387,6 +390,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
 }
 
 - (RCTImageLoaderCancellationBlock)_loadURLRequest:(NSURLRequest *)request
+                                              size:(CGSize)size
+                                             scale:(CGFloat)scale
+                                        resizeMode:(RCTResizeMode)resizeMode
                                      progressBlock:(RCTImageLoaderProgressBlock)progressHandler
                                    completionBlock:(void (^)(NSError *error, id imageOrData, NSString *fetchDate))completionHandler
 {
@@ -397,6 +403,17 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
                 request.URL.absoluteString);
     return NULL;
   }
+
+  UIImage *image = [[self imageCache] imageForUrl:request.URL.absoluteString
+                                                   size:size
+                                                  scale:scale
+                                             resizeMode:resizeMode
+                                           responseDate:@""];
+  if (image) {
+    completionHandler(nil, image, @"");
+    return ^{ };
+  }
+
 
   RCTNetworking *networking = [_bridge networking];
 


### PR DESCRIPTION
to: @spikebrehm 

This PR modified the RN image cache directly. It seems to have been not using it in most cases, and i changed the code paths so that it does. I also changed the cache key to be more aggressive. It all seems to work just fine this way.

In the future we will forego this fix with a more robust image loader of our own that can live in application code, and more intelligently share the cache elsewhere.