### PR TITLE
Fix RCTImageLoader crash - Cancel network requests from the correct queue

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -457,7 +457,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
 
   // Download image
   __weak __typeof(self) weakSelf = self;
-  RCTNetworkTask *task = [networking networkTaskWithRequest:request completionBlock:^(NSURLResponse *response, NSData *data, NSError *error) {
+  __block RCTNetworkTask *task = [networking networkTaskWithRequest:request
+                                                    completionBlock:^(NSURLResponse *response, NSData *data, NSError *error) 
+  {
     __typeof(self) strongSelf = weakSelf;
     if (!strongSelf) {
       return;
@@ -497,8 +499,15 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   }
 
   return ^{
-    [task cancel];
-    [weakSelf dequeueTasks];
+    __typeof(self) strongSelf = weakSelf;
+    if (!strongSelf || !task) {
+      return;
+    }
+    dispatch_async(strongSelf->_URLRequestQueue, ^{
+      [task cancel];
+      task = nil;
+    });
+    [strongSelf dequeueTasks];
   };
 }
 
@@ -513,7 +522,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   __block volatile uint32_t cancelled = 0;
   __block dispatch_block_t cancelLoad = nil;
   dispatch_block_t cancellationBlock = ^{
-    if (cancelLoad) {
+    if (cancelLoad && !cancelled) {
       cancelLoad();
     }
     OSAtomicOr32Barrier(1, &cancelled);

--- a/Libraries/Network/RCTNetworkTask.m
+++ b/Libraries/Network/RCTNetworkTask.m
@@ -53,6 +53,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   _incrementalDataBlock = nil;
   _responseBlock = nil;
   _uploadProgressBlock = nil;
+  _requestToken = nil;
 }
 
 - (void)dispatchCallback:(dispatch_block_t)callback
@@ -66,6 +67,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)start
 {
+  if (_status != RCTNetworkTaskPending) {
+    RCTLogError(@"RCTNetworkTask was already started or completed");
+    return;
+  }
+
   if (_requestToken == nil) {
     id token = [_handler sendRequest:_request withDelegate:self];
     if ([self validateRequestToken:token]) {
@@ -77,6 +83,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)cancel
 {
+  if (_status == RCTNetworkTaskFinished) {
+      return;
+  }
+
   _status = RCTNetworkTaskFinished;
   id token = _requestToken;
   if (token && [_handler respondsToSelector:@selector(cancelRequest:)]) {


### PR DESCRIPTION
Picked from here:
https://github.com/facebook/react-native/commit/26be005b0a8349afc7f00d8eb0bfe92be85021af