### PR TITLE
Allow TouchableNativeFeedback ripple to be bound by child view border radius

### DIFF
--- a/Examples/UIExplorer/js/TouchableExample.js
+++ b/Examples/UIExplorer/js/TouchableExample.js
@@ -89,11 +89,29 @@ exports.examples = [
       height: 100,
       transform: [{scale: mScale}]
     };
+    const roundedStyle = {
+      backgroundColor: 'white',
+      borderTopLeftRadius: 20,
+      borderTopRightRadius: 10,
+      borderBottomLeftRadius: 0,
+      borderBottomRightRadius: 40
+    };
     return (
       <View>
         <View style={styles.row}>
           <TouchableNativeFeedback>
             <Animated.View style={style}/>
+          </TouchableNativeFeedback>
+        </View>
+        <View style={[styles.row, styles.block]}>
+          <TouchableNativeFeedback
+            background={TouchableNativeFeedback.Ripple(null, false, true)}>
+            <View style={roundedStyle}>
+              <Text style={[styles.button, styles.nativeFeedbackButton, styles.block]}>
+                TouchableNativeFeedback.Ripple can be configured to be
+                constrained to the child's border radii.
+              </Text>
+            </View>
           </TouchableNativeFeedback>
         </View>
       </View>

--- a/Examples/UIExplorer/js/TouchableExample.js
+++ b/Examples/UIExplorer/js/TouchableExample.js
@@ -94,7 +94,7 @@ exports.examples = [
       borderTopLeftRadius: 20,
       borderTopRightRadius: 10,
       borderBottomLeftRadius: 0,
-      borderBottomRightRadius: 40
+      borderBottomRightRadius: 40,
     };
     return (
       <View>
@@ -109,7 +109,7 @@ exports.examples = [
             <View style={roundedStyle}>
               <Text style={[styles.button, styles.nativeFeedbackButton, styles.block]}>
                 TouchableNativeFeedback.Ripple can be configured to be
-                constrained to the child's border radii.
+                constrained to the child‘s border radii.
               </Text>
             </View>
           </TouchableNativeFeedback>

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -26,7 +26,7 @@ var rippleBackgroundPropType = PropTypes.shape({
   type: React.PropTypes.oneOf(['RippleAndroid']),
   color: PropTypes.number,
   borderless: PropTypes.bool,
-  borderWithRadius: PropTypes.bool
+  borderRadiusContain: PropTypes.bool,
 });
 
 var themeAttributeBackgroundPropType = PropTypes.shape({
@@ -119,15 +119,15 @@ var TouchableNativeFeedback = React.createClass({
      *
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
-     * @param borderWithRadius If the ripple should be contained with the target's border-radius, if defined. Only
+     * @param borderRadiusContain If the ripple should be contained with the target's border-radius, if defined. Only
      * used if {@code borderless} is false.
      */
-    Ripple: function(color: string, borderless: boolean, borderWithRadius: boolean) {
+    Ripple: function(color: string, borderless: boolean, borderRadiusContain: boolean) {
       return {
         type: 'RippleAndroid',
         color: processColor(color),
         borderless: borderless,
-        borderWithRadius: borderWithRadius
+        borderWithRadius: borderRadiusContain,
       };
     },
 

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -26,6 +26,7 @@ var rippleBackgroundPropType = PropTypes.shape({
   type: React.PropTypes.oneOf(['RippleAndroid']),
   color: PropTypes.number,
   borderless: PropTypes.bool,
+  borderWithRadius: PropTypes.bool
 });
 
 var themeAttributeBackgroundPropType = PropTypes.shape({
@@ -118,9 +119,16 @@ var TouchableNativeFeedback = React.createClass({
      *
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
+     * @param borderWithRadius If the ripple should be contained with the target's border-radius, if defined. Only
+     * used if {@code borderless} is false.
      */
-    Ripple: function(color: string, borderless: boolean) {
-      return {type: 'RippleAndroid', color: processColor(color), borderless: borderless};
+    Ripple: function(color: string, borderless: boolean, borderWithRadius: boolean) {
+      return {
+        type: 'RippleAndroid',
+        color: processColor(color),
+        borderless: borderless,
+        borderWithRadius: borderWithRadius
+      };
     },
 
     canUseNativeForeground: function() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -12,8 +12,8 @@ package com.facebook.react.views.view;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.PaintDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
 import android.util.TypedValue;
@@ -22,6 +22,8 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.uimanager.ViewProps;
+
+import javax.annotation.Nullable;
 
 /**
  * Utility class that helps with converting android drawable description used in JS to an actual
@@ -32,8 +34,15 @@ public class ReactDrawableHelper {
   private static final TypedValue sResolveOutValue = new TypedValue();
 
   public static Drawable createDrawableFromJSDescription(
+    Context context,
+    ReadableMap drawableDescriptionDict) {
+    return createDrawableFromJSDescription(context, drawableDescriptionDict, null);
+  }
+
+  public static Drawable createDrawableFromJSDescription(
       Context context,
-      ReadableMap drawableDescriptionDict) {
+      ReadableMap drawableDescriptionDict,
+      @Nullable float[] cornerRadii) {
     String type = drawableDescriptionDict.getString("type");
     if ("ThemeAttrAndroid".equals(type)) {
       String attr = drawableDescriptionDict.getString("attribute");
@@ -75,11 +84,16 @@ public class ReactDrawableHelper {
               "couldn't be resolved into a drawable");
         }
       }
-      Drawable mask = null;
+      PaintDrawable mask = null;
       if (!drawableDescriptionDict.hasKey("borderless") ||
-          drawableDescriptionDict.isNull("borderless") ||
-          !drawableDescriptionDict.getBoolean("borderless")) {
-        mask = new ColorDrawable(Color.WHITE);
+        drawableDescriptionDict.isNull("borderless") ||
+        !drawableDescriptionDict.getBoolean("borderless")) {
+        mask = new PaintDrawable(Color.WHITE);
+        if (cornerRadii != null &&
+          drawableDescriptionDict.hasKey("borderWithRadius") &&
+          drawableDescriptionDict.getBoolean("borderWithRadius")) {
+          mask.setCornerRadii(cornerRadii);
+        }
       }
       ColorStateList colorStateList = new ColorStateList(
           new int[][] {new int[]{}},

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -262,7 +262,7 @@ public class ReactViewBackgroundDrawable extends Drawable {
     float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
     float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
 
-    return  new float[] {
+    return new float[] {
       topLeftRadius,
       topLeftRadius,
       topRightRadius,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -255,6 +255,25 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
   }
 
+  /* package */ float[] getBorderRadii() {
+    float defaultBorderRadius = !CSSConstants.isUndefined(mBorderRadius) ? mBorderRadius : 0;
+    float topLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[0]) ? mBorderCornerRadii[0] : defaultBorderRadius;
+    float topRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[1]) ? mBorderCornerRadii[1] : defaultBorderRadius;
+    float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
+    float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
+
+    return  new float[] {
+      topLeftRadius,
+      topLeftRadius,
+      topRightRadius,
+      topRightRadius,
+      bottomRightRadius,
+      bottomRightRadius,
+      bottomLeftRadius,
+      bottomLeftRadius
+    };
+  }
+
   private void updatePath() {
     if (!mNeedUpdatePathForBorderRadius) {
       return;
@@ -277,25 +296,12 @@ public class ReactViewBackgroundDrawable extends Drawable {
       mTempRectForBorderRadius.inset(fullBorderWidth * 0.5f, fullBorderWidth * 0.5f);
     }
 
-    float defaultBorderRadius = !CSSConstants.isUndefined(mBorderRadius) ? mBorderRadius : 0;
-    float topLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[0]) ? mBorderCornerRadii[0] : defaultBorderRadius;
-    float topRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[1]) ? mBorderCornerRadii[1] : defaultBorderRadius;
-    float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
-    float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
+    float[] borderRadii = getBorderRadii();
 
     mPathForBorderRadius.addRoundRect(
-        mTempRectForBorderRadius,
-        new float[] {
-          topLeftRadius,
-          topLeftRadius,
-          topRightRadius,
-          topRightRadius,
-          bottomRightRadius,
-          bottomRightRadius,
-          bottomLeftRadius,
-          bottomLeftRadius
-        },
-        Path.Direction.CW);
+      mTempRectForBorderRadius,
+      borderRadii,
+      Path.Direction.CW);
 
     float extraRadiusForOutline = 0;
 
@@ -306,14 +312,14 @@ public class ReactViewBackgroundDrawable extends Drawable {
     mPathForBorderRadiusOutline.addRoundRect(
       mTempRectForBorderRadiusOutline,
       new float[] {
-        topLeftRadius + extraRadiusForOutline,
-        topLeftRadius + extraRadiusForOutline,
-        topRightRadius + extraRadiusForOutline,
-        topRightRadius + extraRadiusForOutline,
-        bottomRightRadius + extraRadiusForOutline,
-        bottomRightRadius + extraRadiusForOutline,
-        bottomLeftRadius + extraRadiusForOutline,
-        bottomLeftRadius + extraRadiusForOutline
+        borderRadii[0] + extraRadiusForOutline,
+        borderRadii[1] + extraRadiusForOutline,
+        borderRadii[2] + extraRadiusForOutline,
+        borderRadii[3] + extraRadiusForOutline,
+        borderRadii[4] + extraRadiusForOutline,
+        borderRadii[5] + extraRadiusForOutline,
+        borderRadii[6] + extraRadiusForOutline,
+        borderRadii[7] + extraRadiusForOutline
       },
       Path.Direction.CW);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -9,8 +9,6 @@
 
 package com.facebook.react.views.view;
 
-import javax.annotation.Nullable;
-
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -22,12 +20,15 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.uimanager.*;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
+
+import javax.annotation.Nullable;
 
 /**
  * Backing for a React View. Has support for borders, but since borders aren't common, lazy
@@ -93,6 +94,7 @@ public class ReactViewGroup extends ViewGroup implements
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private @Nullable OnInterceptTouchEventListener mOnInterceptTouchEventListener;
   private boolean mNeedsOffscreenAlphaCompositing = false;
+  private @Nullable ReadableMap mNativeBackground;
 
   public ReactViewGroup(Context context) {
     super(context);
@@ -133,11 +135,26 @@ public class ReactViewGroup extends ViewGroup implements
         "This method is not supported for ReactViewGroup instances");
   }
 
-  public void setTranslucentBackgroundDrawable(@Nullable Drawable background) {
+  public void setNativeBackground(@Nullable ReadableMap nativeBackground) {
+    mNativeBackground = nativeBackground;
+    refreshTranslucentBackgroundDrawable();
+  }
+
+  public void refreshTranslucentBackgroundDrawable() {
     // it's required to call setBackground to null, as in some of the cases we may set new
     // background to be a layer drawable that contains a drawable that has been previously setup
     // as a background previously. This will not work correctly as the drawable callback logic is
     // messed up in AOSP
+
+    Drawable background = null;
+    if (mNativeBackground != null) {
+      float[] cornerRadii = null;
+      if (mReactBackgroundDrawable != null) {
+        cornerRadii = mReactBackgroundDrawable.getBorderRadii();
+      }
+      background = ReactDrawableHelper.createDrawableFromJSDescription(getContext(), mNativeBackground, cornerRadii);
+    }
+
     super.setBackground(null);
     if (mReactBackgroundDrawable != null && background != null) {
       LayerDrawable layerDrawable =
@@ -206,10 +223,12 @@ public class ReactViewGroup extends ViewGroup implements
 
   public void setBorderRadius(float borderRadius) {
     getOrCreateReactViewBackground().setRadius(borderRadius);
+    refreshTranslucentBackgroundDrawable();
   }
 
   public void setBorderRadius(float borderRadius, int position) {
     getOrCreateReactViewBackground().setRadius(borderRadius, position);
+    refreshTranslucentBackgroundDrawable();
   }
 
   public void setBorderStyle(@Nullable String style) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -100,8 +100,7 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
-    view.setTranslucentBackgroundDrawable(bg == null ?
-            null : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
+    view.setNativeBackground(bg);
   }
 
   @TargetApi(Build.VERSION_CODES.M)


### PR DESCRIPTION
Currently, there is no way to make an android background ripple be bounded to a circular child i.e. TouchableNativeFeedback will fill the full rectangle space occupied by a circular child. 

This PR is heavily modeled after [this pr](https://github.com/facebook/react-native/pull/6515/files), but with the difference the "border-bounded" ripple is opt-in. This change was made because RN maintainers reverted the commit because the "rectangular" ripple behavior was desired for some components, such as dialogs.

The general approach seemed to be good (have `ReactViewBackgroundDrawable` expose it's
radii and pass them to the `ReactDrawableHelper` to add a mask to the Ripple.)

To achieve the opt-in behavior, I modified TouchableNativeFeedback.Ripple to accept a boolean `borderWithRadius`.

Tests:

Added an example to the UIExplorer android project.

![bounded_ripple](https://cloud.githubusercontent.com/assets/1754153/21950401/24707700-d9af-11e6-915c-1bdff9b41f9c.gif)

