### PR TITLE
Add lineSpacing prop to Android.

### DIFF
--- a/Examples/UIExplorer/js/ScrollViewSimpleExample.js
+++ b/Examples/UIExplorer/js/ScrollViewSimpleExample.js
@@ -57,6 +57,20 @@ class ScrollViewSimpleExample extends React.Component {
         {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
       </ScrollView>
     );
+    items.push(
+      <ScrollView
+        key={'scrollViewSnap'}
+        horizontal
+        snapToInterval={210}
+        pagingEnabled
+      >
+        {this.makeItems(NUM_ITEMS, [
+          styles.itemWrapper,
+          styles.horizontalItemWrapper,
+          styles.horizontalPagingItemWrapper,
+        ])}
+      </ScrollView>
+    );
 
     var verticalScrollView = (
       <ScrollView style={styles.verticalScrollView}>
@@ -83,7 +97,10 @@ var styles = StyleSheet.create({
   },
   horizontalItemWrapper: {
     padding: 50
-  }
+  },
+  horizontalPagingItemWrapper: {
+    width: 200,
+  },
 });
 
 module.exports = ScrollViewSimpleExample;

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1735,12 +1735,6 @@ function createAnimatedComponent(Component: any): any {
       var callback = () => {
         if (this._component.setNativeProps) {
           if (!this._propsAnimated.__isNative) {
-            if (this._component.viewConfig == null) {
-              var ctor = this._component.constructor;
-              var componentName = ctor.displayName || ctor.name || '<Unknown Component>';
-              throw new Error(componentName + ' "viewConfig" is not defined.');
-            }
-
             this._component.setNativeProps(
               this._propsAnimated.__getAnimatedValue()
             );

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -86,6 +86,19 @@ export type AnnotationDragState = $Enum<{
 
 const MapView = React.createClass({
 
+  componentWillMount: function() {
+    console.warn(
+      'MapView is now deprecated and will be removed from React Native in version 0.42. ' +
+      'Please use the react-native-maps module which is more feature complete ' +
+      'and works on Android too: https://github.com/airbnb/react-native-maps\n' +
+      'It is actively maintained and widely used.\n\n' +
+      'Once MapView is removed from React Native in v0.42, we will release the ' +
+      'code as deprecated-react-native-ios-mapview. You will be able to ' +
+      'continue using that and migrate to react-native-maps your own pace later.\n\n' +
+      'For more info, check out https://github.com/facebook/react-native/pull/10500'
+    );
+  },
+
   mixins: [NativeMethodsMixin],
 
   propTypes: {

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -273,8 +273,8 @@ const ScrollView = React.createClass({
      * When set, causes the scroll view to stop at multiples of the value of
      * `snapToInterval`. This can be used for paginating through children
      * that have lengths smaller than the scroll view. Used in combination
-     * with `snapToAlignment`.
-     * @platform ios
+     * with `snapToAlignment` on ios.
+     * Supported for horizontal scrollview on android. Use in combination with `pagingEnabled`.
      */
     snapToInterval: PropTypes.number,
     /**

--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -20,13 +20,12 @@
 #import "RCTNetworking.h"
 #import "RCTUtils.h"
 
-static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 1048576; // 1MB
+static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 1048576 * 4; // 4MB
 
 static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat scale,
                                      RCTResizeMode resizeMode, NSString *responseDate)
 {
-    return [NSString stringWithFormat:@"%@|%g|%g|%g|%zd|%@",
-            imageTag, size.width, size.height, scale, resizeMode, responseDate];
+    return [NSString stringWithFormat:@"%@", imageTag];
 }
 
 @implementation RCTImageCache
@@ -38,7 +37,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
 - (instancetype)init
 {
   _decodedImageCache = [NSCache new];
-  _decodedImageCache.totalCostLimit = 5 * 1024 * 1024; // 5MB
+  _decodedImageCache.totalCostLimit = 32 * 1024 * 1024; // 32MB
 
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(clearCache)

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -376,6 +376,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
     } else {
       // Use networking module to load image
       cancelLoad = [strongSelf _loadURLRequest:request
+                                          size:size
+                                         scale:scale
+                                    resizeMode:resizeMode
                                  progressBlock:progressHandler
                                completionBlock:completionHandler];
     }
@@ -391,6 +394,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
 }
 
 - (RCTImageLoaderCancellationBlock)_loadURLRequest:(NSURLRequest *)request
+                                              size:(CGSize)size
+                                             scale:(CGFloat)scale
+                                        resizeMode:(RCTResizeMode)resizeMode
                                      progressBlock:(RCTImageLoaderProgressBlock)progressHandler
                                    completionBlock:(void (^)(NSError *error, id imageOrData, NSString *fetchDate))completionHandler
 {
@@ -401,6 +407,17 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
                 request.URL.absoluteString);
     return NULL;
   }
+
+  UIImage *image = [[self imageCache] imageForUrl:request.URL.absoluteString
+                                                   size:size
+                                                  scale:scale
+                                             resizeMode:resizeMode
+                                           responseDate:@""];
+  if (image) {
+    completionHandler(nil, image, @"");
+    return ^{ };
+  }
+
 
   RCTNetworking *networking = [_bridge networking];
 

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -461,9 +461,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
 
   // Download image
   __weak __typeof(self) weakSelf = self;
-  __block RCTNetworkTask *task =
-  [networking networkTaskWithRequest:request
-                     completionBlock:^(NSURLResponse *response, NSData *data, NSError *error) {
+  __block RCTNetworkTask *task = [networking networkTaskWithRequest:request
+                                                    completionBlock:^(NSURLResponse *response, NSData *data, NSError *error) 
+  {
     __typeof(self) strongSelf = weakSelf;
     if (!strongSelf) {
       return;

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -219,7 +219,7 @@ RCT_EXPORT_MODULE()
     self.remoteNotificationCallbacks[notificationId] = completionHandler;
   }
 
-  [self sendEventWithName:@"remoteNotificationReceived" body:notification.userInfo];
+  [self sendEventWithName:@"remoteNotificationReceived" body:remoteNotification];
 }
 
 - (void)handleRemoteNotificationsRegistered:(NSNotification *)notification

--- a/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
+++ b/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
@@ -139,6 +139,12 @@ var NativeMethodsMixin = {
    * Manipulation](docs/direct-manipulation.html)).
    */
   setNativeProps: function(nativeProps: Object) {
+    if (!this.viewConfig) {
+      var ctor = this.constructor;
+      var componentName = ctor.displayName || ctor.name || '<Unknown Component>';
+      invariant(false, componentName + ' "viewConfig" is not defined.');
+    }
+
     if (__DEV__) {
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.38.0"
+  s.version             = "0.38.100"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = package['version']
+  s.version             = "0.38.0-rc.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.38.0-rc.1"
+  s.version             = "0.38.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.38.0-rc.0"
+  s.version             = "0.38.0-rc.1"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React/CSSLayout/CSSLayout-internal.h
+++ b/React/CSSLayout/CSSLayout-internal.h
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "CSSLayout.h"
+#include "CSSNodeList.h"
+
+CSS_EXTERN_C_BEGIN
+
+typedef struct CSSCachedMeasurement {
+  float availableWidth;
+  float availableHeight;
+  CSSMeasureMode widthMeasureMode;
+  CSSMeasureMode heightMeasureMode;
+
+  float computedWidth;
+  float computedHeight;
+} CSSCachedMeasurement;
+
+// This value was chosen based on empiracle data. Even the most complicated
+// layouts should not require more than 16 entries to fit within the cache.
+enum { CSS_MAX_CACHED_RESULT_COUNT = 16 };
+
+typedef struct CSSLayout {
+  float position[4];
+  float dimensions[2];
+  CSSDirection direction;
+
+  float computedFlexBasis;
+
+  // Instead of recomputing the entire layout every single time, we
+  // cache some information to break early when nothing changed
+  uint32_t generationCount;
+  CSSDirection lastParentDirection;
+
+  uint32_t nextCachedMeasurementsIndex;
+  CSSCachedMeasurement cachedMeasurements[CSS_MAX_CACHED_RESULT_COUNT];
+  float measuredDimensions[2];
+
+  CSSCachedMeasurement cached_layout;
+} CSSLayout;
+
+typedef struct CSSStyle {
+  CSSDirection direction;
+  CSSFlexDirection flexDirection;
+  CSSJustify justifyContent;
+  CSSAlign alignContent;
+  CSSAlign alignItems;
+  CSSAlign alignSelf;
+  CSSPositionType positionType;
+  CSSWrapType flexWrap;
+  CSSOverflow overflow;
+  float flexGrow;
+  float flexShrink;
+  float flexBasis;
+  float margin[CSSEdgeCount];
+  float position[CSSEdgeCount];
+  float padding[CSSEdgeCount];
+  float border[CSSEdgeCount];
+  float dimensions[2];
+  float minDimensions[2];
+  float maxDimensions[2];
+} CSSStyle;
+
+typedef struct CSSNode {
+  CSSStyle style;
+  CSSLayout layout;
+  uint32_t lineIndex;
+  bool hasNewLayout;
+  bool isTextNode;
+  CSSNodeRef parent;
+  CSSNodeListRef children;
+  bool isDirty;
+
+  struct CSSNode *nextChild;
+
+  CSSSize (*measure)(void *context,
+                     float width,
+                     CSSMeasureMode widthMode,
+                     float height,
+                     CSSMeasureMode heightMode);
+  void (*print)(void *context);
+  void *context;
+} CSSNode;
+
+CSS_EXTERN_C_END

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.38.0
+VERSION_NAME=0.38.100
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.38.0-rc.0
+VERSION_NAME=0.38.0-rc.1
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.38.0-rc.1
+VERSION_NAME=0.38.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1000.0.0-master
+VERSION_NAME=0.38.0-rc.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -73,6 +73,7 @@ public class ViewProps {
   public static final String FONT_STYLE = "fontStyle";
   public static final String FONT_FAMILY = "fontFamily";
   public static final String LINE_HEIGHT = "lineHeight";
+  public static final String LETTER_SPACING = "letterSpacing";
   public static final String NEEDS_OFFSCREEN_ALPHA_COMPOSITING = "needsOffscreenAlphaCompositing";
   public static final String NUMBER_OF_LINES = "numberOfLines";
   public static final String ELLIPSIZE_MODE = "ellipsizeMode";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -48,6 +48,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
   private @Nullable String mScrollPerfTag;
   private @Nullable Drawable mEndBackground;
   private int mEndFillColor = Color.TRANSPARENT;
+  private int mSnapInterval = 0;
 
   public ReactHorizontalScrollView(Context context) {
     this(context, null);
@@ -87,6 +88,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
   public void setPagingEnabled(boolean pagingEnabled) {
     mPagingEnabled = pagingEnabled;
   }
+
+  public void setSnapInterval(int snapInterval) { mSnapInterval = snapInterval; }
 
   @Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
@@ -295,6 +298,13 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
     postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
   }
 
+  private int getSnapInterval() {
+    if (mSnapInterval != 0) {
+      return mSnapInterval;
+    }
+    return getWidth();
+  }
+
   /**
    * This will smooth scroll us to the nearest page boundary
    * It currently just looks at where the content is relative to the page and slides to the nearest
@@ -302,7 +312,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
    * scrolling.
    */
   private void smoothScrollToPage(int velocity) {
-    int width = getWidth();
+    int width = getSnapInterval();
     int currentX = getScrollX();
     // TODO (t11123799) - Should we do anything beyond linear accounting of the velocity
     int predictedX = currentX + velocity;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -12,9 +12,11 @@ package com.facebook.react.views.scroll;
 import javax.annotation.Nullable;
 
 import android.graphics.Color;
+import android.util.DisplayMetrics;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -56,6 +58,12 @@ public class ReactHorizontalScrollViewManager
   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
   public void setScrollEnabled(ReactHorizontalScrollView view, boolean value) {
     view.setScrollEnabled(value);
+  }
+
+  @ReactProp(name = "snapToInterval")
+  public void setSnapToInterval(ReactHorizontalScrollView view, int snapToInterval) {
+    DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
+    view.setSnapInterval((int)(snapToInterval * screenDisplayMetrics.density));
   }
 
   @ReactProp(name = "showsHorizontalScrollIndicator")

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -304,6 +304,7 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   }
 
   private float mLineHeight = Float.NaN;
+  private float mLetterSpacing = Float.NaN;
   private boolean mIsColorSet = false;
   private int mColor;
   private boolean mIsBackgroundColorSet = false;
@@ -358,6 +359,14 @@ public class ReactTextShadowNode extends LayoutShadowNode {
     if (!isVirtual) {
       setMeasureFunction(TEXT_MEASURE_FUNCTION);
     }
+  }
+
+  public float getLetterSpacing() {
+    return mLetterSpacing;
+  }
+
+  public int getFontSize() {
+    return mFontSize;
   }
 
   // Returns a line height which takes into account the requested line height
@@ -415,6 +424,12 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   @ReactProp(name = ViewProps.LINE_HEIGHT, defaultInt = UNSET)
   public void setLineHeight(int lineHeight) {
     mLineHeight = lineHeight == UNSET ? Float.NaN : PixelUtil.toPixelFromSP(lineHeight);
+    markUpdated();
+  }
+
+  @ReactProp(name = ViewProps.LETTER_SPACING, defaultFloat = UNSET)
+  public void setLetterSpacing(float letterSpacing) {
+    mLetterSpacing = letterSpacing == UNSET ? Float.NaN : letterSpacing;
     markUpdated();
   }
 
@@ -591,6 +606,8 @@ public class ReactTextShadowNode extends LayoutShadowNode {
           getPadding(Spacing.TOP),
           getPadding(Spacing.END),
           getPadding(Spacing.BOTTOM),
+          getLetterSpacing(),
+          getFontSize(),
           getTextAlign()
         );
       uiViewOperationQueue.enqueueUpdateExtraData(getReactTag(), reactTextUpdate);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -25,6 +25,8 @@ public class ReactTextUpdate {
   private final float mPaddingTop;
   private final float mPaddingRight;
   private final float mPaddingBottom;
+  private final float mLetterSpacing;
+  private final int mFontSize;
   private final int mTextAlign;
 
   public ReactTextUpdate(
@@ -35,6 +37,8 @@ public class ReactTextUpdate {
     float paddingTop,
     float paddingEnd,
     float paddingBottom,
+    float letterSpacing,
+    int fontSize,
     int textAlign) {
     mText = text;
     mJsEventCounter = jsEventCounter;
@@ -43,6 +47,8 @@ public class ReactTextUpdate {
     mPaddingTop = paddingTop;
     mPaddingRight = paddingEnd;
     mPaddingBottom = paddingBottom;
+    mLetterSpacing = letterSpacing;
+    mFontSize = fontSize;
     mTextAlign = textAlign;
   }
 
@@ -72,6 +78,14 @@ public class ReactTextUpdate {
 
   public float getPaddingBottom() {
     return mPaddingBottom;
+  }
+
+  public float getLetterSpacing() {
+    return mLetterSpacing;
+  }
+
+  public int getFontSize() {
+    return mFontSize;
   }
 
   public int getTextAlign() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -22,6 +22,8 @@ import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.facebook.csslayout.FloatUtil;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactCompoundView;
 import com.facebook.react.uimanager.ViewDefaults;
 import com.facebook.react.views.view.ReactViewBackgroundDrawable;
@@ -36,6 +38,7 @@ public class ReactTextView extends TextView implements ReactCompoundView {
   private int mDefaultGravityVertical;
   private boolean mTextIsSelectable;
   private float mLineHeight = Float.NaN;
+  private float mLetterSpacing = Float.NaN;
   private int mTextAlign = Gravity.NO_GRAVITY;
   private int mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;
   private TextUtils.TruncateAt mEllipsizeLocation = TextUtils.TruncateAt.END;
@@ -63,6 +66,18 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       (int) Math.floor(update.getPaddingTop()),
       (int) Math.floor(update.getPaddingRight()),
       (int) Math.floor(update.getPaddingBottom()));
+
+    float nextLetterSpacing = update.getLetterSpacing();
+    int fontSize = update.getFontSize();
+    if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing)) {
+      mLetterSpacing = nextLetterSpacing;
+      if(Float.isNaN(mLetterSpacing)) {
+        setLetterSpacing((float)0.0);
+      } else {
+        //calculate EM from proper font pixels
+        setLetterSpacing(1+(mLetterSpacing-PixelUtil.toDIPFromPixel(fontSize))/PixelUtil.toDIPFromPixel(fontSize));
+      }
+    }
 
     int nextTextAlign = update.getTextAlign();
     if (mTextAlign != nextTextAlign) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -15,6 +15,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build.VERSION;
 import android.text.Layout;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -67,15 +68,18 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       (int) Math.floor(update.getPaddingRight()),
       (int) Math.floor(update.getPaddingBottom()));
 
-    float nextLetterSpacing = update.getLetterSpacing();
-    int fontSize = update.getFontSize();
-    if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing)) {
-      mLetterSpacing = nextLetterSpacing;
-      if(Float.isNaN(mLetterSpacing)) {
-        setLetterSpacing((float)0.0);
-      } else {
-        //calculate EM from proper font pixels
-        setLetterSpacing(1+(mLetterSpacing-PixelUtil.toDIPFromPixel(fontSize))/PixelUtil.toDIPFromPixel(fontSize));
+    // API 21+: https://developer.android.com/reference/android/widget/TextView.html#setLetterSpacing(float)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      float nextLetterSpacing = update.getLetterSpacing();
+      int fontSize = update.getFontSize();
+      if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing)) {
+        mLetterSpacing = nextLetterSpacing;
+        if(Float.isNaN(mLetterSpacing)) {
+          setLetterSpacing((float)0.0);
+        } else {
+          //calculate EM from proper font pixels
+          setLetterSpacing(1+(mLetterSpacing-PixelUtil.toDIPFromPixel(fontSize))/PixelUtil.toDIPFromPixel(fontSize));
+        }
       }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -96,6 +96,8 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
         (int) Math.floor(getPadding(Spacing.END)),
         (int) Math.floor(getPadding(Spacing.BOTTOM)));
 
+    editText.setLetterSpacing(getLetterSpacing());
+
     if (mNumberOfLines != UNSET) {
       editText.setLines(mNumberOfLines);
     }
@@ -146,6 +148,8 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
           getPadding(Spacing.TOP),
           getPadding(Spacing.END),
           getPadding(Spacing.BOTTOM),
+          getLetterSpacing(),
+          getFontSize(),
           mTextAlign
         );
       uiViewOperationQueue.enqueueUpdateExtraData(getReactTag(), reactTextUpdate);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -96,7 +96,10 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
         (int) Math.floor(getPadding(Spacing.END)),
         (int) Math.floor(getPadding(Spacing.BOTTOM)));
 
-    editText.setLetterSpacing(getLetterSpacing());
+    // API 21+: https://developer.android.com/reference/android/widget/TextView.html#setLetterSpacing(float)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      editText.setLetterSpacing(getLetterSpacing());
+    }
 
     if (mNumberOfLines != UNSET) {
       editText.setLines(mNumberOfLines);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.38.0",
+  "version": "0.38.100",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.38.0-rc.0",
+  "version": "0.38.0-rc.1",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.38.0-rc.1",
+  "version": "0.38.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "1000.0.0",
+  "version": "0.38.0-rc.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
## Summary
This PR makes enables `lineSpacing` on Android.  It is based on https://github.com/facebook/react-native/pull/9420, differing only with respect to minor library import references.

## Pictures of changes

### Android fonts on Airbnb app
<img width="603" alt="screen shot 2017-01-23 at 9 23 25 pm" src="https://cloud.githubusercontent.com/assets/3782704/22235374/1ab5bab0-e1b4-11e6-8e47-2dc34255ef8e.png">

### Android fonts specific use cases:

<img width="585" alt="screen shot 2017-01-23 at 9 25 30 pm" src="https://cloud.githubusercontent.com/assets/3782704/22235379/214f9328-e1b4-11e6-973d-1a10f474ae12.png">


<img width="581" alt="screen shot 2017-01-23 at 9 27 42 pm" src="https://cloud.githubusercontent.com/assets/3782704/22235382/23c41e76-e1b4-11e6-89ca-4b6af6c94541.png">
