### PR TITLE
Revert changes in 0.38.101

### DIFF
--- a/Examples/UIExplorer/js/TouchableExample.js
+++ b/Examples/UIExplorer/js/TouchableExample.js
@@ -89,29 +89,11 @@ exports.examples = [
       height: 100,
       transform: [{scale: mScale}]
     };
-    const roundedStyle = {
-      backgroundColor: 'white',
-      borderTopLeftRadius: 20,
-      borderTopRightRadius: 10,
-      borderBottomLeftRadius: 0,
-      borderBottomRightRadius: 40,
-    };
     return (
       <View>
         <View style={styles.row}>
           <TouchableNativeFeedback>
             <Animated.View style={style}/>
-          </TouchableNativeFeedback>
-        </View>
-        <View style={[styles.row, styles.block]}>
-          <TouchableNativeFeedback
-            background={TouchableNativeFeedback.Ripple(null, false, true)}>
-            <View style={roundedStyle}>
-              <Text style={[styles.button, styles.nativeFeedbackButton, styles.block]}>
-                TouchableNativeFeedback.Ripple can be configured to be
-                constrained to the child‘s border radii.
-              </Text>
-            </View>
           </TouchableNativeFeedback>
         </View>
       </View>

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -26,7 +26,6 @@ var rippleBackgroundPropType = PropTypes.shape({
   type: React.PropTypes.oneOf(['RippleAndroid']),
   color: PropTypes.number,
   borderless: PropTypes.bool,
-  borderRadiusContain: PropTypes.bool,
 });
 
 var themeAttributeBackgroundPropType = PropTypes.shape({
@@ -119,16 +118,9 @@ var TouchableNativeFeedback = React.createClass({
      *
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
-     * @param borderRadiusContain If the ripple should be contained with the target's border-radius, if defined. Only
-     * used if {@code borderless} is false.
      */
-    Ripple: function(color: string, borderless: boolean, borderRadiusContain: boolean) {
-      return {
-        type: 'RippleAndroid',
-        color: processColor(color),
-        borderless: borderless,
-        borderWithRadius: borderRadiusContain,
-      };
+    Ripple: function(color: string, borderless: boolean) {
+      return {type: 'RippleAndroid', color: processColor(color), borderless: borderless};
     },
 
     canUseNativeForeground: function() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -12,8 +12,8 @@ package com.facebook.react.views.view;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.PaintDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
 import android.util.TypedValue;
@@ -22,8 +22,6 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.uimanager.ViewProps;
-
-import javax.annotation.Nullable;
 
 /**
  * Utility class that helps with converting android drawable description used in JS to an actual
@@ -34,15 +32,8 @@ public class ReactDrawableHelper {
   private static final TypedValue sResolveOutValue = new TypedValue();
 
   public static Drawable createDrawableFromJSDescription(
-    Context context,
-    ReadableMap drawableDescriptionDict) {
-    return createDrawableFromJSDescription(context, drawableDescriptionDict, null);
-  }
-
-  public static Drawable createDrawableFromJSDescription(
       Context context,
-      ReadableMap drawableDescriptionDict,
-      @Nullable float[] cornerRadii) {
+      ReadableMap drawableDescriptionDict) {
     String type = drawableDescriptionDict.getString("type");
     if ("ThemeAttrAndroid".equals(type)) {
       String attr = drawableDescriptionDict.getString("attribute");
@@ -84,16 +75,11 @@ public class ReactDrawableHelper {
               "couldn't be resolved into a drawable");
         }
       }
-      PaintDrawable mask = null;
+      Drawable mask = null;
       if (!drawableDescriptionDict.hasKey("borderless") ||
-        drawableDescriptionDict.isNull("borderless") ||
-        !drawableDescriptionDict.getBoolean("borderless")) {
-        mask = new PaintDrawable(Color.WHITE);
-        if (cornerRadii != null &&
-          drawableDescriptionDict.hasKey("borderWithRadius") &&
-          drawableDescriptionDict.getBoolean("borderWithRadius")) {
-          mask.setCornerRadii(cornerRadii);
-        }
+          drawableDescriptionDict.isNull("borderless") ||
+          !drawableDescriptionDict.getBoolean("borderless")) {
+        mask = new ColorDrawable(Color.WHITE);
       }
       ColorStateList colorStateList = new ColorStateList(
           new int[][] {new int[]{}},

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -255,25 +255,6 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
   }
 
-  /* package */ float[] getBorderRadii() {
-    float defaultBorderRadius = !CSSConstants.isUndefined(mBorderRadius) ? mBorderRadius : 0;
-    float topLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[0]) ? mBorderCornerRadii[0] : defaultBorderRadius;
-    float topRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[1]) ? mBorderCornerRadii[1] : defaultBorderRadius;
-    float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
-    float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
-
-    return new float[] {
-      topLeftRadius,
-      topLeftRadius,
-      topRightRadius,
-      topRightRadius,
-      bottomRightRadius,
-      bottomRightRadius,
-      bottomLeftRadius,
-      bottomLeftRadius
-    };
-  }
-
   private void updatePath() {
     if (!mNeedUpdatePathForBorderRadius) {
       return;
@@ -296,12 +277,25 @@ public class ReactViewBackgroundDrawable extends Drawable {
       mTempRectForBorderRadius.inset(fullBorderWidth * 0.5f, fullBorderWidth * 0.5f);
     }
 
-    float[] borderRadii = getBorderRadii();
+    float defaultBorderRadius = !CSSConstants.isUndefined(mBorderRadius) ? mBorderRadius : 0;
+    float topLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[0]) ? mBorderCornerRadii[0] : defaultBorderRadius;
+    float topRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[1]) ? mBorderCornerRadii[1] : defaultBorderRadius;
+    float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
+    float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
 
     mPathForBorderRadius.addRoundRect(
-      mTempRectForBorderRadius,
-      borderRadii,
-      Path.Direction.CW);
+        mTempRectForBorderRadius,
+        new float[] {
+          topLeftRadius,
+          topLeftRadius,
+          topRightRadius,
+          topRightRadius,
+          bottomRightRadius,
+          bottomRightRadius,
+          bottomLeftRadius,
+          bottomLeftRadius
+        },
+        Path.Direction.CW);
 
     float extraRadiusForOutline = 0;
 
@@ -312,14 +306,14 @@ public class ReactViewBackgroundDrawable extends Drawable {
     mPathForBorderRadiusOutline.addRoundRect(
       mTempRectForBorderRadiusOutline,
       new float[] {
-        borderRadii[0] + extraRadiusForOutline,
-        borderRadii[1] + extraRadiusForOutline,
-        borderRadii[2] + extraRadiusForOutline,
-        borderRadii[3] + extraRadiusForOutline,
-        borderRadii[4] + extraRadiusForOutline,
-        borderRadii[5] + extraRadiusForOutline,
-        borderRadii[6] + extraRadiusForOutline,
-        borderRadii[7] + extraRadiusForOutline
+        topLeftRadius + extraRadiusForOutline,
+        topLeftRadius + extraRadiusForOutline,
+        topRightRadius + extraRadiusForOutline,
+        topRightRadius + extraRadiusForOutline,
+        bottomRightRadius + extraRadiusForOutline,
+        bottomRightRadius + extraRadiusForOutline,
+        bottomLeftRadius + extraRadiusForOutline,
+        bottomLeftRadius + extraRadiusForOutline
       },
       Path.Direction.CW);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -9,6 +9,8 @@
 
 package com.facebook.react.views.view;
 
+import javax.annotation.Nullable;
+
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -20,15 +22,12 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.uimanager.*;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
-
-import javax.annotation.Nullable;
 
 /**
  * Backing for a React View. Has support for borders, but since borders aren't common, lazy
@@ -94,7 +93,6 @@ public class ReactViewGroup extends ViewGroup implements
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private @Nullable OnInterceptTouchEventListener mOnInterceptTouchEventListener;
   private boolean mNeedsOffscreenAlphaCompositing = false;
-  private @Nullable ReadableMap mNativeBackground;
 
   public ReactViewGroup(Context context) {
     super(context);
@@ -135,26 +133,11 @@ public class ReactViewGroup extends ViewGroup implements
         "This method is not supported for ReactViewGroup instances");
   }
 
-  public void setNativeBackground(@Nullable ReadableMap nativeBackground) {
-    mNativeBackground = nativeBackground;
-    refreshTranslucentBackgroundDrawable();
-  }
-
-  public void refreshTranslucentBackgroundDrawable() {
+  public void setTranslucentBackgroundDrawable(@Nullable Drawable background) {
     // it's required to call setBackground to null, as in some of the cases we may set new
     // background to be a layer drawable that contains a drawable that has been previously setup
     // as a background previously. This will not work correctly as the drawable callback logic is
     // messed up in AOSP
-
-    Drawable background = null;
-    if (mNativeBackground != null) {
-      float[] cornerRadii = null;
-      if (mReactBackgroundDrawable != null) {
-        cornerRadii = mReactBackgroundDrawable.getBorderRadii();
-      }
-      background = ReactDrawableHelper.createDrawableFromJSDescription(getContext(), mNativeBackground, cornerRadii);
-    }
-
     super.setBackground(null);
     if (mReactBackgroundDrawable != null && background != null) {
       LayerDrawable layerDrawable =
@@ -223,12 +206,10 @@ public class ReactViewGroup extends ViewGroup implements
 
   public void setBorderRadius(float borderRadius) {
     getOrCreateReactViewBackground().setRadius(borderRadius);
-    refreshTranslucentBackgroundDrawable();
   }
 
   public void setBorderRadius(float borderRadius, int position) {
     getOrCreateReactViewBackground().setRadius(borderRadius, position);
-    refreshTranslucentBackgroundDrawable();
   }
 
   public void setBorderStyle(@Nullable String style) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -100,7 +100,8 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
-    view.setNativeBackground(bg);
+    view.setTranslucentBackgroundDrawable(bg == null ?
+            null : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
   }
 
   @TargetApi(Build.VERSION_CODES.M)


### PR DESCRIPTION
This reverts b59f99b7e7f69b138860d12959eec9b46cd790a3 and fe00e2d1ec834f670c5faaf09c28950b049fccba.

The approach to add touchable ripple to backgrounds with border-radius
breaks other React Native backgrounds on Android. Specifically,
any background that is not set through setNativeBackground will
not be rendered.
