### PR TITLE
Adds corner-radius support to ripples created in TouchableNativeFeedback

### DIFF
--- a/Examples/UIExplorer/js/TouchableExample.js
+++ b/Examples/UIExplorer/js/TouchableExample.js
@@ -87,6 +87,7 @@ exports.examples = [
       backgroundColor: 'rgb(180, 64, 119)',
       width: 200,
       height: 100,
+      borderRadius: 20,
       transform: [{scale: mScale}]
     };
     return (

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -12,8 +12,8 @@ package com.facebook.react.views.view;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.PaintDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
 import android.util.TypedValue;
@@ -22,6 +22,8 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.uimanager.ViewProps;
+
+import javax.annotation.Nullable;
 
 /**
  * Utility class that helps with converting android drawable description used in JS to an actual
@@ -32,8 +34,15 @@ public class ReactDrawableHelper {
   private static final TypedValue sResolveOutValue = new TypedValue();
 
   public static Drawable createDrawableFromJSDescription(
+    Context context,
+    ReadableMap drawableDescriptionDict) {
+    return createDrawableFromJSDescription(context, drawableDescriptionDict, null);
+  }
+
+  public static Drawable createDrawableFromJSDescription(
       Context context,
-      ReadableMap drawableDescriptionDict) {
+      ReadableMap drawableDescriptionDict,
+      @Nullable float[] cornerRadii) {
     String type = drawableDescriptionDict.getString("type");
     if ("ThemeAttrAndroid".equals(type)) {
       String attr = drawableDescriptionDict.getString("attribute");
@@ -75,11 +84,14 @@ public class ReactDrawableHelper {
               "couldn't be resolved into a drawable");
         }
       }
-      Drawable mask = null;
+      PaintDrawable mask = null;
       if (!drawableDescriptionDict.hasKey("borderless") ||
-          drawableDescriptionDict.isNull("borderless") ||
-          !drawableDescriptionDict.getBoolean("borderless")) {
-        mask = new ColorDrawable(Color.WHITE);
+        drawableDescriptionDict.isNull("borderless") ||
+        !drawableDescriptionDict.getBoolean("borderless")) {
+        mask = new PaintDrawable(Color.WHITE);
+        if (cornerRadii != null) {
+          mask.setCornerRadii(cornerRadii);
+        }
       }
       ColorStateList colorStateList = new ColorStateList(
           new int[][] {new int[]{}},

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -255,6 +255,25 @@ public class ReactViewBackgroundDrawable extends Drawable {
     }
   }
 
+  /* package */ float[] getBorderRadii() {
+    float defaultBorderRadius = !CSSConstants.isUndefined(mBorderRadius) ? mBorderRadius : 0;
+    float topLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[0]) ? mBorderCornerRadii[0] : defaultBorderRadius;
+    float topRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[1]) ? mBorderCornerRadii[1] : defaultBorderRadius;
+    float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
+    float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
+
+    return new float[] {
+      topLeftRadius,
+      topLeftRadius,
+      topRightRadius,
+      topRightRadius,
+      bottomRightRadius,
+      bottomRightRadius,
+      bottomLeftRadius,
+      bottomLeftRadius
+    };
+  }
+
   private void updatePath() {
     if (!mNeedUpdatePathForBorderRadius) {
       return;
@@ -277,25 +296,12 @@ public class ReactViewBackgroundDrawable extends Drawable {
       mTempRectForBorderRadius.inset(fullBorderWidth * 0.5f, fullBorderWidth * 0.5f);
     }
 
-    float defaultBorderRadius = !CSSConstants.isUndefined(mBorderRadius) ? mBorderRadius : 0;
-    float topLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[0]) ? mBorderCornerRadii[0] : defaultBorderRadius;
-    float topRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[1]) ? mBorderCornerRadii[1] : defaultBorderRadius;
-    float bottomRightRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[2]) ? mBorderCornerRadii[2] : defaultBorderRadius;
-    float bottomLeftRadius = mBorderCornerRadii != null && !CSSConstants.isUndefined(mBorderCornerRadii[3]) ? mBorderCornerRadii[3] : defaultBorderRadius;
+    float[] borderRadii = getBorderRadii();
 
     mPathForBorderRadius.addRoundRect(
-        mTempRectForBorderRadius,
-        new float[] {
-          topLeftRadius,
-          topLeftRadius,
-          topRightRadius,
-          topRightRadius,
-          bottomRightRadius,
-          bottomRightRadius,
-          bottomLeftRadius,
-          bottomLeftRadius
-        },
-        Path.Direction.CW);
+      mTempRectForBorderRadius,
+      borderRadii,
+      Path.Direction.CW);
 
     float extraRadiusForOutline = 0;
 
@@ -306,14 +312,14 @@ public class ReactViewBackgroundDrawable extends Drawable {
     mPathForBorderRadiusOutline.addRoundRect(
       mTempRectForBorderRadiusOutline,
       new float[] {
-        topLeftRadius + extraRadiusForOutline,
-        topLeftRadius + extraRadiusForOutline,
-        topRightRadius + extraRadiusForOutline,
-        topRightRadius + extraRadiusForOutline,
-        bottomRightRadius + extraRadiusForOutline,
-        bottomRightRadius + extraRadiusForOutline,
-        bottomLeftRadius + extraRadiusForOutline,
-        bottomLeftRadius + extraRadiusForOutline
+        borderRadii[0] + extraRadiusForOutline,
+        borderRadii[1] + extraRadiusForOutline,
+        borderRadii[2] + extraRadiusForOutline,
+        borderRadii[3] + extraRadiusForOutline,
+        borderRadii[4] + extraRadiusForOutline,
+        borderRadii[5] + extraRadiusForOutline,
+        borderRadii[6] + extraRadiusForOutline,
+        borderRadii[7] + extraRadiusForOutline
       },
       Path.Direction.CW);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -9,8 +9,6 @@
 
 package com.facebook.react.views.view;
 
-import javax.annotation.Nullable;
-
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -22,12 +20,15 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.uimanager.*;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
+
+import javax.annotation.Nullable;
 
 /**
  * Backing for a React View. Has support for borders, but since borders aren't common, lazy
@@ -93,6 +94,7 @@ public class ReactViewGroup extends ViewGroup implements
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private @Nullable OnInterceptTouchEventListener mOnInterceptTouchEventListener;
   private boolean mNeedsOffscreenAlphaCompositing = false;
+  private @Nullable ReadableMap mNativeBackground;
 
   public ReactViewGroup(Context context) {
     super(context);
@@ -133,16 +135,33 @@ public class ReactViewGroup extends ViewGroup implements
         "This method is not supported for ReactViewGroup instances");
   }
 
-  public void setTranslucentBackgroundDrawable(@Nullable Drawable background) {
+  public void setNativeBackground(@Nullable ReadableMap nativeBackground) {
+    mNativeBackground = nativeBackground;
+    refreshTranslucentBackgroundDrawable();
+  }
+
+  public void refreshTranslucentBackgroundDrawable() {
     // it's required to call setBackground to null, as in some of the cases we may set new
     // background to be a layer drawable that contains a drawable that has been previously setup
     // as a background previously. This will not work correctly as the drawable callback logic is
     // messed up in AOSP
+
+    Drawable background = null;
+    if (mNativeBackground != null) {
+      float[] cornerRadii = null;
+      if (mReactBackgroundDrawable != null) {
+        cornerRadii = mReactBackgroundDrawable.getBorderRadii();
+      }
+      background = ReactDrawableHelper.createDrawableFromJSDescription(getContext(), mNativeBackground, cornerRadii);
+    }
+
     super.setBackground(null);
     if (mReactBackgroundDrawable != null && background != null) {
       LayerDrawable layerDrawable =
           new LayerDrawable(new Drawable[] {mReactBackgroundDrawable, background});
       super.setBackground(layerDrawable);
+    } else if (mReactBackgroundDrawable != null && background == null) {
+      super.setBackground(mReactBackgroundDrawable);
     } else if (background != null) {
       super.setBackground(background);
     }
@@ -206,10 +225,12 @@ public class ReactViewGroup extends ViewGroup implements
 
   public void setBorderRadius(float borderRadius) {
     getOrCreateReactViewBackground().setRadius(borderRadius);
+    refreshTranslucentBackgroundDrawable();
   }
 
   public void setBorderRadius(float borderRadius, int position) {
     getOrCreateReactViewBackground().setRadius(borderRadius, position);
+    refreshTranslucentBackgroundDrawable();
   }
 
   public void setBorderStyle(@Nullable String style) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -100,8 +100,7 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
-    view.setTranslucentBackgroundDrawable(bg == null ?
-            null : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
+    view.setNativeBackground(bg);
   }
 
   @TargetApi(Build.VERSION_CODES.M)


### PR DESCRIPTION
This follows the same approach as fe00e2d1ec834f670c5faaf09c28950b049fccba
but fixes a bug in ReactViewGroup#refreshTranslucentBackgroundDrawable
where a view that has a borderRadius, but no nativeBackground would
not be rendered due to a missing condition case.

Testing:

Tested change in React Native DLS explorer and was able to add ripples to rounded button components with no adverse affects.