### PR TITLE
Enable linespacing for versions >= Lollipop (5.0)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -73,6 +73,7 @@ public class ViewProps {
   public static final String FONT_STYLE = "fontStyle";
   public static final String FONT_FAMILY = "fontFamily";
   public static final String LINE_HEIGHT = "lineHeight";
+  public static final String LETTER_SPACING = "letterSpacing";
   public static final String NEEDS_OFFSCREEN_ALPHA_COMPOSITING = "needsOffscreenAlphaCompositing";
   public static final String NUMBER_OF_LINES = "numberOfLines";
   public static final String ELLIPSIZE_MODE = "ellipsizeMode";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -331,6 +331,7 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   }
 
   private float mLineHeight = Float.NaN;
+  private float mLetterSpacing = Float.NaN;
   private boolean mIsColorSet = false;
   private boolean mAllowFontScaling = true;
   private int mColor;
@@ -388,6 +389,14 @@ public class ReactTextShadowNode extends LayoutShadowNode {
     if (!isVirtual()) {
       setMeasureFunction(mTextMeasureFunction);
     }
+  }
+
+  public float getLetterSpacing() {
+    return mLetterSpacing;
+  }
+
+  public int getFontSize() {
+    return mFontSize;
   }
 
   // Returns a line height which takes into account the requested line height
@@ -462,6 +471,12 @@ public class ReactTextShadowNode extends LayoutShadowNode {
       setLineHeight(mLineHeightInput);
       markUpdated();
     }
+  }
+
+  @ReactProp(name = ViewProps.LETTER_SPACING, defaultFloat = UNSET)
+  public void setLetterSpacing(float letterSpacing) {
+    mLetterSpacing = letterSpacing == UNSET ? Float.NaN : letterSpacing;
+    markUpdated();
   }
 
   @ReactProp(name = ViewProps.TEXT_ALIGN)
@@ -653,6 +668,8 @@ public class ReactTextShadowNode extends LayoutShadowNode {
           getPadding(Spacing.TOP),
           getPadding(Spacing.END),
           getPadding(Spacing.BOTTOM),
+          getLetterSpacing(),
+          getFontSize(),
           getTextAlign(),
           mTextBreakStrategy
         );

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -26,6 +26,8 @@ public class ReactTextUpdate {
   private final float mPaddingTop;
   private final float mPaddingRight;
   private final float mPaddingBottom;
+  private final float mLetterSpacing;
+  private final int mFontSize;
   private final int mTextAlign;
   private final int mTextBreakStrategy;
 
@@ -62,6 +64,8 @@ public class ReactTextUpdate {
     float paddingTop,
     float paddingEnd,
     float paddingBottom,
+    float letterSpacing,
+    int fontSize,
     int textAlign,
     int textBreakStrategy) {
     mText = text;
@@ -71,6 +75,8 @@ public class ReactTextUpdate {
     mPaddingTop = paddingTop;
     mPaddingRight = paddingEnd;
     mPaddingBottom = paddingBottom;
+    mLetterSpacing = letterSpacing;
+    mFontSize = fontSize;
     mTextAlign = textAlign;
     mTextBreakStrategy = textBreakStrategy;
   }
@@ -101,6 +107,14 @@ public class ReactTextUpdate {
 
   public float getPaddingBottom() {
     return mPaddingBottom;
+  }
+
+  public float getLetterSpacing() {
+    return mLetterSpacing;
+  }
+
+  public int getFontSize() {
+    return mFontSize;
   }
 
   public int getTextAlign() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -23,6 +23,8 @@ import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.facebook.csslayout.FloatUtil;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactCompoundView;
 import com.facebook.react.uimanager.ViewDefaults;
 import com.facebook.react.views.view.ReactViewBackgroundDrawable;
@@ -37,6 +39,7 @@ public class ReactTextView extends TextView implements ReactCompoundView {
   private int mDefaultGravityVertical;
   private boolean mTextIsSelectable;
   private float mLineHeight = Float.NaN;
+  private float mLetterSpacing = Float.NaN;
   private int mTextAlign = Gravity.NO_GRAVITY;
   private int mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;
   private TextUtils.TruncateAt mEllipsizeLocation = TextUtils.TruncateAt.END;
@@ -64,6 +67,21 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       (int) Math.floor(update.getPaddingTop()),
       (int) Math.floor(update.getPaddingRight()),
       (int) Math.floor(update.getPaddingBottom()));
+
+    // API 21+: https://developer.android.com/reference/android/widget/TextView.html#setLetterSpacing(float)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      float nextLetterSpacing = update.getLetterSpacing();
+      int fontSize = update.getFontSize();
+      if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing)) {
+        mLetterSpacing = nextLetterSpacing;
+        if(Float.isNaN(mLetterSpacing)) {
+          setLetterSpacing((float)0.0);
+        } else {
+          //calculate EM from proper font pixels
+          setLetterSpacing(1+(mLetterSpacing-PixelUtil.toDIPFromPixel(fontSize))/PixelUtil.toDIPFromPixel(fontSize));
+        }
+      }
+    }
 
     int nextTextAlign = update.getTextAlign();
     if (mTextAlign != nextTextAlign) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -103,6 +103,11 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
         (int) Math.floor(getPadding(Spacing.END)),
         (int) Math.floor(getPadding(Spacing.BOTTOM)));
 
+    // API 21+: https://developer.android.com/reference/android/widget/TextView.html#setLetterSpacing(float)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      editText.setLetterSpacing(getLetterSpacing());
+    }
+
     if (mNumberOfLines != UNSET) {
       editText.setLines(mNumberOfLines);
     }
@@ -176,6 +181,8 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
           getPadding(Spacing.TOP),
           getPadding(Spacing.END),
           getPadding(Spacing.BOTTOM),
+          getLetterSpacing(),
+          getFontSize(),
           mTextAlign,
           mTextBreakStrategy
         );


### PR DESCRIPTION
## Summary
This PR makes enables `lineSpacing` on Android.  It is based on https://github.com/facebook/react-native/pull/9420, differing only with respect to minor library import references.

This deprecates an older PR: https://github.com/airbnb/react-native/pull/8

## Pictures of changes

### Android fonts on Airbnb app
<img width="603" alt="screen shot 2017-01-23 at 9 23 25 pm" src="https://cloud.githubusercontent.com/assets/3782704/22235374/1ab5bab0-e1b4-11e6-8e47-2dc34255ef8e.png">

### Android fonts specific use cases:

<img width="585" alt="screen shot 2017-01-23 at 9 25 30 pm" src="https://cloud.githubusercontent.com/assets/3782704/22235379/214f9328-e1b4-11e6-973d-1a10f474ae12.png">


<img width="581" alt="screen shot 2017-01-23 at 9 27 42 pm" src="https://cloud.githubusercontent.com/assets/3782704/22235382/23c41e76-e1b4-11e6-89ca-4b6af6c94541.png">
