### PR TITLE
Allow apps to manually control when the dev support tools are enabled

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -236,6 +236,7 @@ public abstract class ReactInstanceManager {
     protected @Nullable RedBoxHandler mRedBoxHandler;
     protected boolean mLazyNativeModulesEnabled;
     protected boolean mLazyViewManagersEnabled;
+    protected boolean mManuallyEnableDevSupport;
 
     protected Builder() {
     }
@@ -379,6 +380,17 @@ public abstract class ReactInstanceManager {
     }
 
     /**
+     * By default, the developer support tools will be enabled and disabled in {@link #onHostPause()}
+     * and {@link #onHostResume(Activity, DefaultHardwareBackBtnHandler)}. This may not be ideal for
+     * multi-activity applications that often switch between native and react native screens or
+     * apps that want tighter control over when the dev tools should be enabled.
+     */
+    public Builder manuallyEnableDevSupport() {
+      mManuallyEnableDevSupport = true;
+      return this;
+    }
+
+    /**
      * Instantiates a new {@link ReactInstanceManagerImpl}.
      * Before calling {@code build}, the following must be called:
      * <ul>
@@ -422,7 +434,8 @@ public abstract class ReactInstanceManager {
         mJSCConfig,
         mRedBoxHandler,
         mLazyNativeModulesEnabled,
-        mLazyViewManagersEnabled);
+        mLazyViewManagersEnabled,
+        mManuallyEnableDevSupport);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java
@@ -138,6 +138,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
   private final JSCConfig mJSCConfig;
   private final boolean mLazyNativeModulesEnabled;
   private final boolean mLazyViewManagersEnabled;
+  private final boolean mManuallyEnableDevSupport;
 
   private final ReactInstanceDevCommandsHandler mDevInterface =
       new ReactInstanceDevCommandsHandler() {
@@ -297,7 +298,8 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
     JSCConfig jscConfig,
     @Nullable RedBoxHandler redBoxHandler,
     boolean lazyNativeModulesEnabled,
-    boolean lazyViewManagersEnabled) {
+    boolean lazyViewManagersEnabled,
+    boolean manuallyEnableDevSupport) {
 
     initializeSoLoaderIfNecessary(applicationContext);
 
@@ -326,6 +328,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
     mJSCConfig = jscConfig;
     mLazyNativeModulesEnabled = lazyNativeModulesEnabled;
     mLazyViewManagersEnabled = lazyViewManagersEnabled;
+    mManuallyEnableDevSupport = manuallyEnableDevSupport;
   }
 
   @Override
@@ -497,7 +500,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
     UiThreadUtil.assertOnUiThread();
 
     mDefaultBackButtonImpl = null;
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
     }
 
@@ -531,7 +534,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
     UiThreadUtil.assertOnUiThread();
 
     mDefaultBackButtonImpl = defaultBackButtonImpl;
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(true);
     }
 


### PR DESCRIPTION
For multi-activity apps, apps that want fine grained control over when the dev support tools are enabled, or apps that frequently switch between native and react native, it isn't ideal to automatically enable and disable the dev tools in onHostPause and onHostResume. This allows apps to manually control when the dev tools are enabled.

@lelandrichardson 