### PR TITLE
Guard two more dev support calls with mManuallyDisableDevSupport

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java
@@ -546,7 +546,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
   public void onHostDestroy() {
     UiThreadUtil.assertOnUiThread();
 
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
     }
 
@@ -565,7 +565,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
   public void destroy() {
     UiThreadUtil.assertOnUiThread();
 
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
     }
 


### PR DESCRIPTION
When manallyEnableDevSupport is set, ReactInstanceManager should never control it. This prevents destroy from disabling dev support.

This and c3cefe70d5176a4eaca7037cc26059dae362286c will be combined in a PR to RN core.

@lelandrichardson 