### PR TITLE
[RN][WiP] Provide the option to request specific location permission for IOS

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -28,6 +28,7 @@ type GeoOptions = {
   maximumAge: number,
   enableHighAccuracy: bool,
   distanceFilter: number,
+  locationPermissionIOS: number,
 }
 
 /**

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -28,7 +28,7 @@ type GeoOptions = {
   maximumAge: number,
   enableHighAccuracy: bool,
   distanceFilter: number,
-  locationPermissionIOS: number,
+  locationPermissionIOS: string,
 }
 
 /**
@@ -143,6 +143,11 @@ var Geolocation = {
       subscriptions = [];
     }
   }
+};
+
+Geolocation.IOS_PERMISSIONS = {
+  WHEN_IN_USE: "locationPermissionIOSWhenInUse",
+  ALWAYS: "locationPermissionIOSAlways",
 };
 
 module.exports = Geolocation;

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -25,6 +25,12 @@ typedef NS_ENUM(NSInteger, RCTPositionErrorCode) {
   RCTPositionErrorTimeout,
 };
 
+typedef NS_ENUM(NSInteger, RCTLocationPermissionCode) {
+  RCTLocationPermissionIOSUnknown = 1,
+  RCTLocationPermissionIOSWhenInUse,
+  RCTLocationPermissionIOSAlways,
+};
+
 #define RCT_DEFAULT_LOCATION_ACCURACY kCLLocationAccuracyHundredMeters
 
 typedef struct {
@@ -32,6 +38,7 @@ typedef struct {
   double maximumAge;
   double accuracy;
   double distanceFilter;
+  RCTLocationPermissionCode locationPermission;
 } RCTLocationOptions;
 
 @implementation RCTConvert (RCTLocationOptions)
@@ -42,12 +49,16 @@ typedef struct {
 
   double distanceFilter = options[@"distanceFilter"] == NULL ? RCT_DEFAULT_LOCATION_ACCURACY
     : [RCTConvert double:options[@"distanceFilter"]] ?: kCLDistanceFilterNone;
+  
+  int locationPermission = options[@"locationPermissionIOS"] == NULL ? RCTLocationPermissionIOSUnknown
+    : [RCTConvert int:options[@"locationPermissionIOS"]] ?: RCTLocationPermissionIOSUnknown
 
   return (RCTLocationOptions){
     .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: INFINITY,
     .maximumAge = [RCTConvert NSTimeInterval:options[@"maximumAge"]] ?: INFINITY,
     .accuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]] ? kCLLocationAccuracyBest : RCT_DEFAULT_LOCATION_ACCURACY,
     .distanceFilter = distanceFilter
+    .locationPermission = locationPermission
   };
 }
 
@@ -133,7 +144,9 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Private API
 
-- (void)beginLocationUpdatesWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy distanceFilter:(CLLocationDistance)distanceFilter
+- (void)beginLocationUpdatesWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy
+                                 distanceFilter:(CLLocationDistance)distanceFilter
+                             locationPermission:(RCTLocationPermissionCode)locationPermission
 {
   if (!_locationManager) {
     _locationManager = [CLLocationManager new];
@@ -141,26 +154,47 @@ RCT_EXPORT_MODULE()
   }
 
   // Request location access permission
-  if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] &&
-    [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
-    [_locationManager requestAlwaysAuthorization];
-
-    // On iOS 9+ we also need to enable background updates
-    NSArray *backgroundModes  = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
-    if(backgroundModes && [backgroundModes containsObject:@"location"]) {
-      if([_locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
-        [_locationManager setAllowsBackgroundLocationUpdates:YES];
+  // If locationPermision option is provided, request that specific permission
+  // Otherwise, fall back to requesting based on the Info.plist
+  switch (locationPermission) {
+    case RCTLocationPermissionIOSAlways:
+      if ([_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+        [self requestAlwaysAuthorizationHelper:_locationManager];
       }
-    }
-  } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] &&
-    [_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
-    [_locationManager requestWhenInUseAuthorization];
+      break;
+    case RCTLocationPermissionIOSWhenInUse:
+      if ([_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+        [_locationManager requestWhenInUseAuthorization];
+      }
+      break;
+    case RCTLocationPermissionIOSUnknown:
+      if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] &&
+          [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+        [self requestAlwaysAuthorizationHelper:_locationManager];
+      } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] &&
+                 [_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+        [_locationManager requestWhenInUseAuthorization];
+      }
+      break;
   }
 
   _locationManager.distanceFilter  = distanceFilter;
   _locationManager.desiredAccuracy = desiredAccuracy;
   // Start observing location
   [_locationManager startUpdatingLocation];
+}
+
+- (void) requestAlwaysAuthorizationHelper:(CLLocationManager)locationManager
+{
+  [locationManager requestAlwaysAuthorization];
+  
+  // On iOS 9+ we also need to enable background updates
+  NSArray *backgroundModes  = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
+  if(backgroundModes && [backgroundModes containsObject:@"location"]) {
+    if([locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
+      [locationManager setAllowsBackgroundLocationUpdates:YES];
+    }
+  }
 }
 
 #pragma mark - Timeout handler
@@ -190,7 +224,9 @@ RCT_EXPORT_METHOD(startObserving:(RCTLocationOptions)options)
     _observerOptions.accuracy = MIN(_observerOptions.accuracy, request.options.accuracy);
   }
 
-  [self beginLocationUpdatesWithDesiredAccuracy:_observerOptions.accuracy distanceFilter:_observerOptions.distanceFilter];
+  [self beginLocationUpdatesWithDesiredAccuracy:_observerOptions.accuracy
+                                 distanceFilter:_observerOptions.distanceFilter
+                             locationPermission:_observerOptions.locationPermission];
   _observingLocation = YES;
 }
 
@@ -264,7 +300,9 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   if (_locationManager) {
     accuracy = MIN(_locationManager.desiredAccuracy, accuracy);
   }
-  [self beginLocationUpdatesWithDesiredAccuracy:accuracy distanceFilter:options.distanceFilter];
+  [self beginLocationUpdatesWithDesiredAccuracy:accuracy
+                                 distanceFilter:options.distanceFilter
+                             locationPermission:options.locationPermission];
 }
 
 #pragma mark - CLLocationManagerDelegate

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -41,6 +41,21 @@ typedef struct {
   RCTLocationPermissionCode locationPermission;
 } RCTLocationOptions;
 
+@implementation RCTConvert (RCTLocationPermissionCode)
+
+RCT_ENUM_CONVERTER(RCTLocationPermissionCode,
+                   (@{
+                      @"locationPermissionIOSUnknown" : @(RCTLocationPermissionIOSUnknown),
+                      @"locationPermissionIOSWhenInUse" : @(RCTLocationPermissionIOSWhenInUse),
+                      @"locationPermissionIOSAlways" : @(RCTLocationPermissionIOSAlways)
+                      }
+                    ),
+                   RCTLocationPermissionIOSUnknown,
+                   integerValue
+                   )
+
+@end
+
 @implementation RCTConvert (RCTLocationOptions)
 
 + (RCTLocationOptions)RCTLocationOptions:(id)json
@@ -51,7 +66,7 @@ typedef struct {
   : [RCTConvert double:options[@"distanceFilter"]] ?: kCLDistanceFilterNone;
   
   int locationPermission = options[@"locationPermissionIOS"] == NULL ? RCTLocationPermissionIOSUnknown
-  : [RCTConvert int:options[@"locationPermissionIOS"]] ?: RCTLocationPermissionIOSUnknown;
+  : [RCTConvert RCTLocationPermissionCode:options[@"locationPermissionIOS"]] ?: RCTLocationPermissionIOSUnknown;
   
   return (RCTLocationOptions){
     .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: INFINITY,

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -46,18 +46,18 @@ typedef struct {
 + (RCTLocationOptions)RCTLocationOptions:(id)json
 {
   NSDictionary<NSString *, id> *options = [RCTConvert NSDictionary:json];
-
+  
   double distanceFilter = options[@"distanceFilter"] == NULL ? RCT_DEFAULT_LOCATION_ACCURACY
-    : [RCTConvert double:options[@"distanceFilter"]] ?: kCLDistanceFilterNone;
+  : [RCTConvert double:options[@"distanceFilter"]] ?: kCLDistanceFilterNone;
   
   int locationPermission = options[@"locationPermissionIOS"] == NULL ? RCTLocationPermissionIOSUnknown
-    : [RCTConvert int:options[@"locationPermissionIOS"]] ?: RCTLocationPermissionIOSUnknown
-
+  : [RCTConvert int:options[@"locationPermissionIOS"]] ?: RCTLocationPermissionIOSUnknown;
+  
   return (RCTLocationOptions){
     .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: INFINITY,
     .maximumAge = [RCTConvert NSTimeInterval:options[@"maximumAge"]] ?: INFINITY,
     .accuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]] ? kCLLocationAccuracyBest : RCT_DEFAULT_LOCATION_ACCURACY,
-    .distanceFilter = distanceFilter
+    .distanceFilter = distanceFilter,
     .locationPermission = locationPermission
   };
 }
@@ -177,14 +177,14 @@ RCT_EXPORT_MODULE()
       }
       break;
   }
-
+  
   _locationManager.distanceFilter  = distanceFilter;
   _locationManager.desiredAccuracy = desiredAccuracy;
   // Start observing location
   [_locationManager startUpdatingLocation];
 }
 
-- (void) requestAlwaysAuthorizationHelper:(CLLocationManager)locationManager
+- (void) requestAlwaysAuthorizationHelper:(CLLocationManager*)locationManager
 {
   [locationManager requestAlwaysAuthorization];
   


### PR DESCRIPTION
<details>
  Thanks for submitting a PR! Please read these instructions carefully:

  - [x] Explain the **motivation** for making this change.
  - [ ] Provide a **test plan** demonstrating that the code is solid.
  - [x] Match the **code formatting** of the rest of the codebase.
  - [x] Target the `master` branch, NOT a "stable" branch.

  Please read the [Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) to learn more about contributing to React Native.
</details>

## Motivation (required)

On IOS, the React Native Geolocation library will make system permission requests based on the capability of the app as defined in `Info.plist`. 

This PR allows the option for feature developers to specify the exact level of location permission request to make, by passing an argument in as part of the options parameter. This is important in scenarios where user privacy and permission regarding location-based features needs to be specifically scoped.

This will prevent situations where apps will ask users for background location permission, even though certain features may only require location in the foreground.

## Test Plan (required)

Work in Progress

## Reviewers
@lelandrichardson
