### PR TITLE
Prevent a crash when a TextInput has no cursor drawable

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -327,6 +327,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       cursorDrawableResField.setAccessible(true);
       int drawableResId = cursorDrawableResField.getInt(view);
 
+      // If the view has no cursor drawable, React Native will crash when
+      // trying to load a resource of id 0.
+      if (drawableResId == 0) {
+        return;
+      }
+
       Drawable drawable = ContextCompat.getDrawable(view.getContext(), drawableResId);
       if (color != null) {
         drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);


### PR DESCRIPTION
@lelandrichardson This is currently causing some screens in our app to crash and is a reasonable guard to add. I'll submit a PR to rn core