### PR TITLE
update native modules mocks

### DIFF
--- a/jest/mockNativeModules.js
+++ b/jest/mockNativeModules.js
@@ -1,0 +1,128 @@
+const rnMockNativeModules = require.requireActual('react-native-mock/build/NativeModules');
+const fbMockNativeModules = {
+  AlertManager: {
+    alertWithArgs: jest.fn(),
+  },
+  AppState: {
+    addEventListener: jest.fn(),
+  },
+  AsyncLocalStorage: {
+    clear: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+    setItem: jest.fn(),
+  },
+  BuildInfo: {
+    appVersion: '0',
+    buildVersion: '0',
+  },
+  Clipboard: {
+    setString: jest.fn(),
+  },
+  DataManager: {
+    queryData: jest.fn(),
+  },
+  FacebookSDK: {
+    login: jest.fn(),
+    logout: jest.fn(),
+    queryGraphPath: jest.fn((path, method, params, callback) => callback()),
+  },
+  FbRelayNativeAdapter: {
+    updateCLC: jest.fn(),
+  },
+  GraphPhotoUpload: {
+    upload: jest.fn(),
+  },
+  I18n: {
+    translationsDictionary: JSON.stringify({
+      'Good bye, {name}!|Bye message': '\u{00A1}Adi\u{00F3}s {name}!',
+    }),
+  },
+  ImageLoader: {
+    getSize: jest.fn(
+      (uri, success) => process.nextTick(() => success(320, 240))
+    ),
+    prefetchImage: jest.fn(),
+  },
+  ImageViewManager: {
+    getSize: jest.fn(
+      (uri, success) => process.nextTick(() => success(320, 240))
+    ),
+    prefetchImage: jest.fn(),
+  },
+  KeyboardObserver: {
+    addListener: jest.fn(),
+    removeListeners: jest.fn(),
+  },
+  ModalFullscreenViewManager: {},
+  Networking: {
+    sendRequest: jest.fn(),
+    abortRequest: jest.fn(),
+    addListener: jest.fn(),
+    removeListeners: jest.fn(),
+  },
+  SourceCode: {
+    scriptURL: null,
+  },
+  StatusBarManager: {
+    setStyle: jest.fn(),
+    setHidden: jest.fn(),
+    setNetworkActivityIndicatorVisible: jest.fn(),
+    setBackgroundColor: jest.fn(),
+    setTranslucent: jest.fn(),
+  },
+  Timing: {
+    createTimer: jest.fn(),
+    deleteTimer: jest.fn(),
+  },
+  UIManager: {
+    customBubblingEventTypes: {},
+    customDirectEventTypes: {},
+    Dimensions: {
+      window: {
+        fontScale: 2,
+        height: 1334,
+        scale: 2,
+        width: 750,
+      },
+    },
+    ModalFullscreenView: {
+      Constants: {},
+    },
+    ScrollView: {
+      Constants: {},
+    },
+    View: {
+      Constants: {},
+    },
+  },
+  WebSocketModule: {
+    connect: jest.fn(),
+    send: jest.fn(),
+    sendBinary: jest.fn(),
+    ping: jest.fn(),
+    close: jest.fn(),
+    addListener: jest.fn(),
+    removeListeners: jest.fn(),
+  },
+};
+
+// Merge Facebook's mocks with react-native-mocks. We'll let RN mocks take precedence; it's more
+// robust and the main difference is FB's use jest.fn() - which is easy to do in test files.
+const mergedMockNativeModules = {};
+Object.keys(fbMockNativeModules).forEach(fbMockModule => {
+  mergedMockNativeModules[fbMockModule] = fbMockNativeModules[fbMockModule];
+});
+Object.keys(rnMockNativeModules).forEach(rnMockNativeModule => {
+  const currentMock = mergedMockNativeModules[rnMockNativeModule];
+  if (currentMock) {
+    mergedMockNativeModules[rnMockNativeModule] = {
+      ...currentMock,
+      ...rnMockNativeModules[rnMockNativeModule],
+    };
+  } else {
+    mergedMockNativeModules[rnMockNativeModule] = rnMockNativeModules[rnMockNativeModule];
+  }
+});
+
+module.exports = mergedMockNativeModules;

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -9,6 +9,7 @@
 'use strict';
 
 const mockComponent = require.requireActual('./mockComponent');
+const mockNativeModules = require.requireActual('./mockNativeModules');
 
 require.requireActual('../packager/react-packager/src/Resolver/polyfills/babelHelpers.js');
 require.requireActual('../packager/react-packager/src/Resolver/polyfills/Object.es7.js');
@@ -64,113 +65,6 @@ jest
   .mock('ensureComponentIsNative', () => () => true);
 
 const mockEmptyObject = {};
-const mockNativeModules = {
-  AlertManager: {
-    alertWithArgs: jest.fn(),
-  },
-  AppState: {
-    addEventListener: jest.fn(),
-  },
-  AsyncLocalStorage: {
-    clear: jest.fn(),
-    getItem: jest.fn(),
-    removeItem: jest.fn(),
-    setItem: jest.fn(),
-  },
-  BuildInfo: {
-    appVersion: '0',
-    buildVersion: '0',
-  },
-  Clipboard: {
-    setString: jest.fn(),
-  },
-  DataManager: {
-    queryData: jest.fn(),
-  },
-  FacebookSDK: {
-    login: jest.fn(),
-    logout: jest.fn(),
-    queryGraphPath: jest.fn((path, method, params, callback) => callback()),
-  },
-  FbRelayNativeAdapter: {
-    updateCLC: jest.fn(),
-  },
-  GraphPhotoUpload: {
-    upload: jest.fn(),
-  },
-  I18n: {
-    translationsDictionary: JSON.stringify({
-      'Good bye, {name}!|Bye message': '\u{00A1}Adi\u{00F3}s {name}!',
-    }),
-  },
-  ImageLoader: {
-    getSize: jest.fn(
-      (uri, success) => process.nextTick(() => success(320, 240))
-    ),
-    prefetchImage: jest.fn(),
-  },
-  ImageViewManager: {
-    getSize: jest.fn(
-      (uri, success) => process.nextTick(() => success(320, 240))
-    ),
-    prefetchImage: jest.fn(),
-  },
-  KeyboardObserver: {
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-  ModalFullscreenViewManager: {},
-  Networking: {
-    sendRequest: jest.fn(),
-    abortRequest: jest.fn(),
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-  SourceCode: {
-    scriptURL: null,
-  },
-  StatusBarManager: {
-    setStyle: jest.fn(),
-    setHidden: jest.fn(),
-    setNetworkActivityIndicatorVisible: jest.fn(),
-    setBackgroundColor: jest.fn(),
-    setTranslucent: jest.fn(),
-  },
-  Timing: {
-    createTimer: jest.fn(),
-    deleteTimer: jest.fn(),
-  },
-  UIManager: {
-    customBubblingEventTypes: {},
-    customDirectEventTypes: {},
-    Dimensions: {
-      window: {
-        fontScale: 2,
-        height: 1334,
-        scale: 2,
-        width: 750,
-      },
-    },
-    ModalFullscreenView: {
-      Constants: {},
-    },
-    ScrollView: {
-      Constants: {},
-    },
-    View: {
-      Constants: {},
-    },
-  },
-  WebSocketModule: {
-    connect: jest.fn(),
-    send: jest.fn(),
-    sendBinary: jest.fn(),
-    ping: jest.fn(),
-    close: jest.fn(),
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-};
 
 Object.keys(mockNativeModules).forEach(module => {
   try {

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "plist": "^1.2.0",
     "promise": "^7.1.1",
     "react-clone-referenced-element": "^1.0.1",
+    "react-native-mock": "^0.3.1",
     "react-timer-mixin": "^0.13.2",
     "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",


### PR DESCRIPTION
## Motivation (required)

I forgot to include this change with the previous PR. Unfortunately the NativeModules mocks that come out of the box with this version of react-native aren't as complete as `react-native-mocks`. I think this is a fairly good solution though - merging the two to get the best of both worlds.

## Test Plan (required)

It makes my specs happy, and doesn't break any of the RN tests.

cc @lelandrichardson @gpeal 