### PR TITLE
[a11y] fix VoiceOver navigation

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -118,6 +118,11 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 
     _backgroundColor = super.backgroundColor;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(voiceOverStatusDidChange:)
+                                                 name:UIAccessibilityVoiceOverStatusChanged
+                                               object:nil];
   }
 
   return self;
@@ -253,6 +258,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
 }
 
+#pragma mark - NSNotificationCenter
+
+- (void)voiceOverStatusDidChange:(__unused NSNotification *)notification {
+  // If VoiceOver is enabled, we need to disable removing clipped subviews to ensure
+  // accessible navigation works properly.
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    self.removeClippedSubviews = NO;
+  }
+}
+
 #pragma mark - Statics for dealing with layoutGuides
 
 + (void)autoAdjustInsetsForView:(UIView<RCTAutoInsetsProtocol> *)parentView
@@ -370,6 +385,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (void)setRemoveClippedSubviews:(BOOL)removeClippedSubviews
 {
+  // removeClippedSubviews prevents VoiceOver from navigating through scrollViews properly,
+  // so we always disable removing clipped subviews when VoiceOver is active.
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    RCTLogInfo(@"removeClippedSubviews is always set to false when VoiceOver is active");
+    removeClippedSubviews = NO;
+  }
   if (!removeClippedSubviews && _removeClippedSubviews) {
     [self react_remountAllSubviews];
   }
@@ -715,6 +736,7 @@ setBorderStyle()
   CGColorRelease(_borderRightColor);
   CGColorRelease(_borderBottomColor);
   CGColorRelease(_borderLeftColor);
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -118,6 +118,11 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 
     _backgroundColor = super.backgroundColor;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(voiceOverStatusDidChange:)
+                                                 name:UIAccessibilityVoiceOverStatusChanged
+                                               object:nil];
   }
 
   return self;
@@ -253,6 +258,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
 }
 
+#pragma mark - NSNotificationCenter
+
+- (void)voiceOverStatusDidChange:(__unused NSNotification *)notification {
+  // If VoiceOver is enabled, we need to disable removing clipped subviews to ensure
+  // accessible navigation works properly.
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    self.removeClippedSubviews = NO;
+  }
+}
+
 #pragma mark - Statics for dealing with layoutGuides
 
 + (void)autoAdjustInsetsForView:(UIView<RCTAutoInsetsProtocol> *)parentView
@@ -370,6 +385,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (void)setRemoveClippedSubviews:(BOOL)removeClippedSubviews
 {
+  // removeClippedSubviews prevents VoiceOver from navigating through scrollViews properly,
+  // so we always disable removing clipped subviews when VoiceOver is active.
+  if (UIAccessibilityIsVoiceOverRunning()) {
+    RCTLogInfo(@"removeClippedSubviews is always set to false when VoiceOver is active");
+    removeClippedSubviews = NO;
+  }
   if (!removeClippedSubviews && _removeClippedSubviews) {
     [self react_remountAllSubviews];
   }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

This commit disables removeClippedSubviews for all react views when VoiceOver is enabled on iOS. The issue is that VoiceOver relys on the view hierarchy to know how to navigate between elements when the user swipes left and right. When removeClippedSubviews is enabled, all views
offscreen are removed from the view hierarchy, causing VoiceOver to stop navigating when it gets to the last view rendered on screen. This PR fixes that by forcing removeClippedSubviews to be false for VoiceOver users.

## Test Plan (required)

Turned on VoiceOver and verified that navigation worked again with these changes.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
