### PR TITLE
Move to Airbnb Metro Bundler

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const babel = require('babel-core');
-const babelRegisterOnly = require('metro-bundler/build/babelRegisterOnly');
+const babelRegisterOnly = require('airbnb-metro-bundler/build/babelRegisterOnly');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
-const transformer = require('metro-bundler/build/transformer.js');
+const transformer = require('airbnb-metro-bundler/build/transformer.js');
 
 const nodeFiles = RegExp([
   '/local-cli/',
@@ -46,7 +46,7 @@ module.exports = {
 
   getCacheKey: createCacheKeyFunction([
     __filename,
-    require.resolve('metro-bundler/build/transformer.js'),
+    require.resolve('airbnb-metro-bundler/build/transformer.js'),
     require.resolve('babel-core/package.json'),
   ]),
 };

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -10,9 +10,9 @@
 
 const mockComponent = require.requireActual('./mockComponent');
 
-require.requireActual('metro-bundler/build/Resolver/polyfills/babelHelpers.js');
-require.requireActual('metro-bundler/build/Resolver/polyfills/Object.es7.js');
-require.requireActual('metro-bundler/build/Resolver/polyfills/error-guard');
+require.requireActual('airbnb-metro-bundler/build/Resolver/polyfills/babelHelpers.js');
+require.requireActual('airbnb-metro-bundler/build/Resolver/polyfills/Object.es7.js');
+require.requireActual('airbnb-metro-bundler/build/Resolver/polyfills/error-guard');
 
 global.__DEV__ = true;
 

--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -12,18 +12,18 @@
 'use strict';
 
 const log = require('../util/log').out('bundle');
-const Server = require('metro-bundler/build/Server');
-const Terminal = require('metro-bundler/build/lib/TerminalClass');
-const TerminalReporter = require('metro-bundler/build/lib/TerminalReporter');
-const TransformCaching = require('metro-bundler/build/lib/TransformCaching');
+const Server = require('airbnb-metro-bundler/build/Server');
+const Terminal = require('airbnb-metro-bundler/build/lib/TerminalClass');
+const TerminalReporter = require('airbnb-metro-bundler/build/lib/TerminalReporter');
+const TransformCaching = require('airbnb-metro-bundler/build/lib/TransformCaching');
 
-const outputBundle = require('metro-bundler/build/shared/output/bundle');
+const outputBundle = require('airbnb-metro-bundler/build/shared/output/bundle');
 const path = require('path');
 const saveAssets = require('./saveAssets');
-const defaultAssetExts = require('metro-bundler/build/defaults').assetExts;
-const defaultSourceExts = require('metro-bundler/build/defaults').sourceExts;
-const defaultPlatforms = require('metro-bundler/build/defaults').platforms;
-const defaultProvidesModuleNodeModules = require('metro-bundler/build/defaults').providesModuleNodeModules;
+const defaultAssetExts = require('airbnb-metro-bundler/build/defaults').assetExts;
+const defaultSourceExts = require('airbnb-metro-bundler/build/defaults').sourceExts;
+const defaultPlatforms = require('airbnb-metro-bundler/build/defaults').platforms;
+const defaultProvidesModuleNodeModules = require('airbnb-metro-bundler/build/defaults').providesModuleNodeModules;
 
 import type {RequestOptions, OutputOptions} from './types.flow';
 import type {ConfigT} from '../util/Config';
@@ -101,6 +101,7 @@ function buildBundle(
       transformModulePath: transformModulePath,
       watch: false,
       workerPath: config.getWorkerPath && config.getWorkerPath(),
+      makeModuleId: config.makeModuleId || ((m, id) => id),
     };
 
     packagerInstance = new Server(options);

--- a/local-cli/bundle/bundle.js
+++ b/local-cli/bundle/bundle.js
@@ -10,7 +10,7 @@
 
 const buildBundle = require('./buildBundle');
 const bundleCommandLineArgs = require('./bundleCommandLineArgs');
-const outputBundle = require('metro-bundler/build/shared/output/bundle');
+const outputBundle = require('airbnb-metro-bundler/build/shared/output/bundle');
 
 /**
  * Builds the bundle starting to look for dependencies at the given entry path.

--- a/local-cli/bundle/types.flow.js
+++ b/local-cli/bundle/types.flow.js
@@ -10,4 +10,4 @@
  */
 'use strict';
 
-export type {OutputOptions, RequestOptions} from 'metro-bundler/build/shared/types.flow';
+export type {OutputOptions, RequestOptions} from 'airbnb-metro-bundler/build/shared/types.flow';

--- a/local-cli/bundle/unbundle.js
+++ b/local-cli/bundle/unbundle.js
@@ -10,7 +10,7 @@
 
 const bundleWithOutput = require('./bundle').withOutput;
 const bundleCommandLineArgs = require('./bundleCommandLineArgs');
-const outputUnbundle = require('metro-bundler/build/shared/output/unbundle');
+const outputUnbundle = require('airbnb-metro-bundler/build/shared/output/unbundle');
 
 /**
  * Builds the bundle starting to look for dependencies at the given entry path.
@@ -26,6 +26,10 @@ module.exports = {
   options: bundleCommandLineArgs.concat({
     command: '--indexed-unbundle',
     description: 'Force indexed unbundle file format, even when building for android',
+    default: false,
+  }, {
+    command: '--asset-unbundle',
+    description: 'Force asset unbundle file format, even when building for ios',
     default: false,
   }),
 };

--- a/local-cli/dependencies/dependencies.js
+++ b/local-cli/dependencies/dependencies.js
@@ -8,7 +8,7 @@
  */
 'use strict';
 
-const ReactPackager = require('metro-bundler');
+const ReactPackager = require('airbnb-metro-bundler');
 
 const denodeify = require('denodeify');
 const fs = require('fs');

--- a/local-cli/server/checkNodeVersion.js
+++ b/local-cli/server/checkNodeVersion.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var chalk = require('chalk');
-var formatBanner = require('metro-bundler/build/lib/formatBanner');
+var formatBanner = require('airbnb-metro-bundler/build/lib/formatBanner');
 var semver = require('semver');
 
 module.exports = function() {

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -14,17 +14,17 @@
 
 require('../../setupBabel')();
 const InspectorProxy = require('./util/inspectorProxy.js');
-const ReactPackager = require('metro-bundler');
-const Terminal = require('metro-bundler/build/lib/TerminalClass');
+const ReactPackager = require('airbnb-metro-bundler');
+const Terminal = require('airbnb-metro-bundler/build/lib/TerminalClass');
 
 const attachHMRServer = require('./util/attachHMRServer');
 const connect = require('connect');
 const copyToClipBoardMiddleware = require('./middleware/copyToClipBoardMiddleware');
 const cpuProfilerMiddleware = require('./middleware/cpuProfilerMiddleware');
-const defaultAssetExts = require('metro-bundler/build/defaults').assetExts;
-const defaultSourceExts = require('metro-bundler/build/defaults').sourceExts;
-const defaultPlatforms = require('metro-bundler/build/defaults').platforms;
-const defaultProvidesModuleNodeModules = require('metro-bundler/build/defaults')
+const defaultAssetExts = require('airbnb-metro-bundler/build/defaults').assetExts;
+const defaultSourceExts = require('airbnb-metro-bundler/build/defaults').sourceExts;
+const defaultPlatforms = require('airbnb-metro-bundler/build/defaults').platforms;
+const defaultProvidesModuleNodeModules = require('airbnb-metro-bundler/build/defaults')
   .providesModuleNodeModules;
 const getDevToolsMiddleware = require('./middleware/getDevToolsMiddleware');
 const http = require('http');
@@ -39,7 +39,7 @@ const unless = require('./middleware/unless');
 const webSocketProxy = require('./util/webSocketProxy.js');
 
 import type {ConfigT} from '../util/Config';
-import type {Reporter} from 'metro-bundler/build/lib/reporting';
+import type {Reporter} from 'airbnb-metro-bundler/build/lib/reporting';
 
 export type Args = {|
   +assetExts: $ReadOnlyArray<string>,
@@ -136,7 +136,7 @@ function getPackagerServer(args, config) {
       LogReporter = require(path.resolve(args.customLogReporterPath));
     }
   } else {
-    LogReporter = require('metro-bundler/build/lib/TerminalReporter');
+    LogReporter = require('airbnb-metro-bundler/build/lib/TerminalReporter');
   }
 
   /* $FlowFixMe: Flow is wrong, Node.js docs specify that process.stdout is an

--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -39,9 +39,9 @@ type DependencyOptions = {|
 |};
 
 /**
- * This is a subset of the actual `metro-bundler`'s `Server` class,
+ * This is a subset of the actual `airbnb-metro-bundler`'s `Server` class,
  * without all the stuff we don't need to know about. This allows us to use
- * `attachHMRServer` with different versions of `metro-bundler` as long as
+ * `attachHMRServer` with different versions of `airbnb-metro-bundler` as long as
  * this specific contract is maintained.
  */
 type PackagerServer<TModule> = {

--- a/local-cli/server/util/getInverseDependencies.js
+++ b/local-cli/server/util/getInverseDependencies.js
@@ -13,9 +13,9 @@
 'use strict';
 
 /**
- * This is a subset of the actual `metro-bundler`'s `ResolutionResponse` class,
+ * This is a subset of the actual `airbnb-metro-bundler`'s `ResolutionResponse` class,
  * without all the stuff we don't need to know about. This allows us to use
- * `getInverseDependencies` with different versions of `metro-bundler`.
+ * `getInverseDependencies` with different versions of `airbnb-metro-bundler`.
  */
 export type ResolutionResponse<TModule> = {
   copy(data: {

--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -12,19 +12,19 @@
 
 const findSymlinksPaths = require('./findSymlinksPaths');
 
-const blacklist = require('metro-bundler/build/blacklist');
+const blacklist = require('airbnb-metro-bundler/build/blacklist');
 const fs = require('fs');
 const invariant = require('fbjs/lib/invariant');
 const path = require('path');
 
-const {providesModuleNodeModules} = require('metro-bundler/build/defaults');
+const {providesModuleNodeModules} = require('airbnb-metro-bundler/build/defaults');
 
 const RN_CLI_CONFIG = 'rn-cli.config.js';
 
-import type {GetTransformOptions, PostMinifyProcess, PostProcessModules} from 'metro-bundler/build/Bundler';
-import type {HasteImpl} from 'metro-bundler/build/node-haste/Module';
-import type {TransformVariants} from 'metro-bundler/build/ModuleGraph/types.flow';
-import type {PostProcessModules as PostProcessModulesForBuck} from 'metro-bundler/build/ModuleGraph/types.flow.js';
+import type {GetTransformOptions, PostMinifyProcess, PostProcessModules} from 'airbnb-metro-bundler/build/Bundler';
+import type {HasteImpl} from 'airbnb-metro-bundler/build/node-haste/Module';
+import type {TransformVariants} from 'airbnb-metro-bundler/build/ModuleGraph/types.flow';
+import type {PostProcessModules as PostProcessModulesForBuck} from 'airbnb-metro-bundler/build/ModuleGraph/types.flow.js';
 
 /**
  * Configuration file of the CLI.
@@ -157,7 +157,7 @@ const Config = {
     },
     getProvidesModuleNodeModules: () => providesModuleNodeModules.slice(),
     getSourceExts: () => [],
-    getTransformModulePath: () => require.resolve('metro-bundler/build/transformer.js'),
+    getTransformModulePath: () => require.resolve('airbnb-metro-bundler/build/transformer.js'),
     getTransformOptions: async () => ({}),
     postMinifyProcess: x => x,
     postProcessModules: modules => modules,

--- a/local-cli/util/worker.js
+++ b/local-cli/util/worker.js
@@ -10,4 +10,4 @@
 'use strict';
 
 require('../../setupBabel')();
-module.exports = require('metro-bundler/build/JSTransformer/worker');
+module.exports = require('airbnb-metro-bundler/build/JSTransformer/worker');

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "left-pad": "^1.1.3",
     "lodash": "^4.16.6",
     "merge-stream": "^1.0.1",
-    "metro-bundler": "^0.7.4",
+    "airbnb-metro-bundler": "^0.7.100",
     "mime": "^1.3.4",
     "mime-types": "2.1.11",
     "minimist": "^1.2.0",

--- a/setupBabel.js
+++ b/setupBabel.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const babelRegisterOnly = require('metro-bundler/build/babelRegisterOnly');
+const babelRegisterOnly = require('airbnb-metro-bundler/build/babelRegisterOnly');
 const escapeRegExp = require('lodash/escapeRegExp');
 const path = require('path');
 


### PR DESCRIPTION
to: @gpeal 

This PR moves our RN fork over to a fork of `metro-bundler`. The only changes in the `metro-bundler` package that this is using is the following:

1. add an option for `--asset-unbundle` to the packager to allow for us to force an asset bundle for iOS (used for easier sourcemap generation, and for diff generation. we are still using RAM Bundles in production).

2. add an option for `rn-cli.config.js` to specify a `makeStableId` function that allows the packager to use stable require identifiers, rather than the auto-incrementing module ids.

I've installed this commit sha locally and verified that everything works as expected.

Hopefully we will be able to contribute some of these things upstream. I've opened a PR [https://github.com/facebook/metro-bundler/pull/44](here)