### PR TITLE
Add missing makeModuleId in packager path

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -162,6 +162,7 @@ function getPackagerServer(args, config) {
     verbose: args.verbose,
     watch: !args.nonPersistent,
     workerPath: config.getWorkerPath(),
+    makeModuleId: config.makeModuleId || ((m, id) => id),
   });
 }
 


### PR DESCRIPTION
to: @gpeal 

I think I had this line added in my local node_modules, but had forgotten to move it over into #36 

This caused some issues with running the packager when merged. This should fix that. Sorry!