### PR TITLE
Update contentInsetAdjustmentBehavior for RCTScrollView on ios 11

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -57,6 +57,11 @@
     _scrollView = scrollView;
     _userData = userData;
     _coalescingKey = coalescingKey;
+#ifdef __IPHONE_11_0
+    if (@available(ios 11, *)) {
+      _scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    }
+#endif
   }
   return self;
 }


### PR DESCRIPTION
The way we use RN, we essentially never want adjustmentbehavior to be anything but `.never`. In future versions of RN where this is better exposed, we might use it differently, but this is a satisfiable fix for now.