### PR TITLE
[Android] Fix text width calculations when letter spacing is set

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -232,11 +232,13 @@ public class ReactTextShadowNode extends LayoutShadowNode {
             YogaMeasureMode heightMode) {
           // TODO(5578671): Handle text direction (see View#getTextDirectionHeuristic)
           TextPaint textPaint = sTextPaintInstance;
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            !Float.isNaN(mLetterSpacing) &&
-            getFontSize() != UNSET) {
-            float fontSizeDip = PixelUtil.toDIPFromPixel(getFontSize());
-            sTextPaintInstance.setLetterSpacing(1 + (mLetterSpacing -  fontSizeDip) / fontSizeDip);
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (!Float.isNaN(mLetterSpacing) && getFontSize() != UNSET) {
+              float fontSizeDip = PixelUtil.toDIPFromPixel(getFontSize());
+              sTextPaintInstance.setLetterSpacing(1 + (mLetterSpacing - fontSizeDip) / fontSizeDip);
+            } else {
+              sTextPaintInstance.setLetterSpacing(0.f);
+            }
           }
           Layout layout;
           Spanned text = Assertions.assertNotNull(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -232,6 +232,12 @@ public class ReactTextShadowNode extends LayoutShadowNode {
             YogaMeasureMode heightMode) {
           // TODO(5578671): Handle text direction (see View#getTextDirectionHeuristic)
           TextPaint textPaint = sTextPaintInstance;
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            !Float.isNaN(mLetterSpacing) &&
+            getFontSize() != UNSET) {
+            float fontSizeDip = PixelUtil.toDIPFromPixel(getFontSize());
+            sTextPaintInstance.setLetterSpacing(1 + (mLetterSpacing -  fontSizeDip) / fontSizeDip);
+          }
           Layout layout;
           Spanned text = Assertions.assertNotNull(
               mPreparedSpannableText,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -72,7 +72,9 @@ public class ReactTextView extends TextView implements ReactCompoundView {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       float nextLetterSpacing = update.getLetterSpacing();
       int fontSize = update.getFontSize();
-      if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing)) {
+      // We can only update the letter spacing if we have a valid font size. It will default to
+      // UNSET (-1) if not explicitly set.
+      if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing) && fontSize > 0) {
         mLetterSpacing = nextLetterSpacing;
         if(Float.isNaN(mLetterSpacing)) {
           setLetterSpacing((float)0.0);


### PR DESCRIPTION
Text measurement with letter spacing was broken on Android prior to this.

The text paint was never given the letter spacing. This will still still be broken, however.

Text measurement was also totally broken if a font size wasn't explicitly set. The letter spacing calculation would blindly use `UNSET` (-1) in its calculations which gives you a bogus value.
@lelandrichardson 