### PR TITLE
Increase prepare js timeout

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketExecutor.m
+++ b/Libraries/WebSocket/RCTWebSocketExecutor.m
@@ -117,7 +117,7 @@ RCT_EXPORT_MODULE()
     initError = error;
     dispatch_semaphore_signal(s);
   }];
-  long runtimeIsReady = dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC));
+  long runtimeIsReady = dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5));
   if (initError) {
     RCTLogInfo(@"Websocket runtime setup failed: %@", initError);
   }


### PR DESCRIPTION
Upstream PR: https://github.com/facebook/react-native/pull/16794

Our codebase is big enough now that we are constantly running into the timeout here for "prepare JS". Right now it's 1s with a retry of 3. On android it's 5s with a retry of 3. I'm just going to make it consistent here.

cc @gpeal 