### PR TITLE
[iOS] Fix TextInput clear button accessibility

### DIFF
--- a/Libraries/Text/RCTUITextField.m
+++ b/Libraries/Text/RCTUITextField.m
@@ -71,6 +71,20 @@
                                                                attributes:attributes];
 }
 
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement {
+  // Always return NO to enumerate child elements. Otherwise the "clear text" button is hidden
+  // from accessibility interface.
+  return NO;
+}
+
+- (BOOL)accessibilityElementsHidden {
+  // If "accessible" prop is set to false on TextInput, disable all accessible children.
+  // Without this function the "clear text" UIButton is still exposed.
+  return ![super isAccessibilityElement];
+}
+
 #pragma mark - Caret Manipulation
 
 - (CGRect)caretRectForPosition:(UITextPosition *)position


### PR DESCRIPTION
## Motivation (required)
This PR makes TextInput "clear text" button accessible. UITextField is wrapped inside a RCTextField (RCUITextField in latest version of RN) control which has `isAccessibleElement` set to TRUE. This prevents iOS accessibility interface from enumerating child elements. This change makes the RCTextField not accessible. But if the `accessible` prop is set to true, then it allows child elements to be enumerated.

## Test Plan (required)
Manually tested with RNTester sample app and accessibility explorer.

## Code Review
@gpeal 