### PR TITLE
[iOS] Fix VoiceOver reading order

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -145,6 +145,21 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   return RCTRecursiveAccessibilityLabel(self);
 }
 
+-(NSInteger)accessibilityElementCount
+{
+  return self.subviews.count;
+}
+
+-(id)accessibilityElementAtIndex:(NSInteger)index
+{
+  return [self.subviews objectAtIndex:index];
+}
+
+-(NSInteger)indexOfAccessibilityElement:(id)element
+{
+  return [self.subviews indexOfObject:element];
+}
+
 - (void)setPointerEvents:(RCTPointerEvents)pointerEvents
 {
   _pointerEvents = pointerEvents;


### PR DESCRIPTION
## Motivation
When iOS enumerates accessible child elements, it sorts them based on screen position. This can cause problems when components on the same row don't have the same size:

![screen shot 2017-12-18 at 3 05 08 pm](https://user-images.githubusercontent.com/280811/34172107-b9ecf9d2-e4a5-11e7-8219-c2ab700c9c32.png)

In the case of Airbnb action footer, the focus goes to the button first before the label, because vertically the button comes first. This behavior makes it difficult to build the layout. On Android, the elements are sorted by the order they are defined, which is easier to understand and control. `shouldGroupAccessibilityChildren` doesn't fix the problem so I had to override enumeration methods.

## Test Plan
Tested in Airbnb app
