### PR TITLE
Support more prop values in Android accessibilityComponentType

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -116,9 +116,11 @@ class Button extends React.Component {
     if (disabled) {
       accessibilityTraits.push('disabled');
     }
+    const accessibilityComponentType = accessibilityTraits;
+
     return (
       <Touchable
-        accessibilityComponentType="button"
+        accessibilityComponentType={accessibilityComponentType}
         accessibilityLabel={accessibilityLabel}
         accessibilityTraits={accessibilityTraits}
         testID={testID}

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -44,9 +44,10 @@ const TouchableWithoutFeedback = createReactClass({
 
   propTypes: {
     accessible: PropTypes.bool,
-    accessibilityComponentType: PropTypes.oneOf(
-      AccessibilityComponentTypes
-    ),
+    accessibilityComponentType: PropTypes.oneOfType([
+      PropTypes.oneOf(AccessibilityComponentTypes),
+      PropTypes.arrayOf(PropTypes.oneOf(AccessibilityComponentTypes)),
+    ]),
     accessibilityTraits: PropTypes.oneOfType([
       PropTypes.oneOf(AccessibilityTraits),
       PropTypes.arrayOf(PropTypes.oneOf(AccessibilityTraits)),

--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -34,7 +34,9 @@ export type AccessibilityComponentType =
   'none' |
   'button' |
   'radiobutton_checked' |
-  'radiobutton_unchecked';
+  'radiobutton_unchecked' |
+  'checked' |
+  'disabled';
 
 module.exports = {
   AccessibilityTraits: [
@@ -61,5 +63,7 @@ module.exports = {
     'button',
     'radiobutton_checked',
     'radiobutton_unchecked',
+    'checked',
+    'disabled',
   ],
 };

--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -33,10 +33,13 @@ export type AccessibilityTrait =
 export type AccessibilityComponentType =
   'none' |
   'button' |
-  'radiobutton_checked' |
-  'radiobutton_unchecked' |
+  'checkbox' |
+  'radiobutton' |
+  'switch' |
   'checked' |
-  'disabled';
+  'disabled' |
+  'radiobutton_checked' |
+  'radiobutton_unchecked';
 
 module.exports = {
   AccessibilityTraits: [
@@ -61,9 +64,12 @@ module.exports = {
   AccessibilityComponentTypes: [
     'none',
     'button',
-    'radiobutton_checked',
-    'radiobutton_unchecked',
+    'checkbox',
+    'radiobutton',
+    'switch',
     'checked',
     'disabled',
+    'radiobutton_checked',
+    'radiobutton_unchecked',
   ],
 };

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -90,12 +90,17 @@ module.exports = {
    * Indicates to accessibility services to treat UI component like a
    * native one. Works for Android only.
    *
-   * Possible values are one of:
+   * Possible values are one or more of:
    *
    * - `'none'`
    * - `'button'`
-   * - `'radiobutton_checked'`
-   * - `'radiobutton_unchecked'`
+   * - `'checkbox'`
+   * - `'radiobutton'`
+   * - `'switch'`
+   * - `'checked'`
+   * - `'disabled'`
+   * - `'radiobutton_checked'` (deprecated)
+   * - `'radiobutton_unchecked'` (deprecated)
    *
    * @platform android
    */

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -99,7 +99,10 @@ module.exports = {
    *
    * @platform android
    */
-  accessibilityComponentType: PropTypes.oneOf(AccessibilityComponentTypes),
+  accessibilityComponentType: PropTypes.oneOfType([
+    PropTypes.oneOf(AccessibilityComponentTypes),
+    PropTypes.arrayOf(PropTypes.oneOf(AccessibilityComponentTypes)),
+  ]),
 
   /**
    * Indicates to accessibility services whether the user should be notified

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityHelper.java
@@ -15,89 +15,130 @@ import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.Button;
 import android.widget.RadioButton;
 
+import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableType;
+
 /**
  * Helper class containing logic for setting accessibility View properties.
  */
 /* package */ class AccessibilityHelper {
 
-  private static final String BUTTON = "button";
-  private static final String RADIOBUTTON_CHECKED = "radiobutton_checked";
-  private static final String RADIOBUTTON_UNCHECKED = "radiobutton_unchecked";
+  static final String BUTTON = "button";
+  static final String RADIOBUTTON = "radiobutton";
+  static final String CHECKED = "checked";
+  static final String DISABLED = "disabled";
+  static final String RADIOBUTTON_CHECKED = "radiobutton_checked";
+  static final String RADIOBUTTON_UNCHECKED = "radiobutton_unchecked";
 
-  private static final View.AccessibilityDelegate BUTTON_DELEGATE =
-      new View.AccessibilityDelegate() {
-        @Override
-        public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
-          super.onInitializeAccessibilityEvent(host, event);
-          event.setClassName(Button.class.getName());
-        }
+  public static void updateAccessibilityComponentType(View view, Dynamic dynamic) {
+    AccessibilityDelegate delegate = new AccessibilityDelegate();
 
-        @Override
-        public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
-          super.onInitializeAccessibilityNodeInfo(host, info);
-          info.setClassName(Button.class.getName());
-        }
-      };
+    if (dynamic.getType() == ReadableType.String) {
+      String prop = dynamic.asString();
+      switch (prop) {
+        case RADIOBUTTON_CHECKED:
+          delegate.setComponentType(RADIOBUTTON);
+          delegate.setComponentType(CHECKED);
+          break;
+        case RADIOBUTTON_UNCHECKED:
+          delegate.setComponentType(RADIOBUTTON);
+          break;
+        default:
+          if (!delegate.setComponentType(prop)) {
+            delegate = null;
+          };
+          break;
+      }
+    } else {
+      ReadableArray componentTypeArray = dynamic.asArray();
 
-  private static final View.AccessibilityDelegate RADIOBUTTON_CHECKED_DELEGATE =
-      new View.AccessibilityDelegate() {
-        @Override
-        public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
-          super.onInitializeAccessibilityEvent(host, event);
-          event.setClassName(RadioButton.class.getName());
-          event.setChecked(true);
-        }
-
-        @Override
-        public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
-          super.onInitializeAccessibilityNodeInfo(host, info);
-          info.setClassName(RadioButton.class.getName());
-          info.setCheckable(true);
-          info.setChecked(true);
-        }
-      };
-
-  private static final View.AccessibilityDelegate RADIOBUTTON_UNCHECKED_DELEGATE =
-      new View.AccessibilityDelegate() {
-        @Override
-        public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
-          super.onInitializeAccessibilityEvent(host, event);
-          event.setClassName(RadioButton.class.getName());
-          event.setChecked(false);
-        }
-
-        @Override
-        public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
-          super.onInitializeAccessibilityNodeInfo(host, info);
-          info.setClassName(RadioButton.class.getName());
-          info.setCheckable(true);
-          info.setChecked(false);
-        }
-      };
-
-  public static void updateAccessibilityComponentType(View view, String componentType) {
-    if (componentType == null) {
-      view.setAccessibilityDelegate(null);
-      return;
+      for (int i = 0; i < componentTypeArray.size(); i++) {
+        String componentType = componentTypeArray.getString(i);
+        if (!delegate.setComponentType(componentType)) {
+          delegate = null;
+          break;
+        };
+      }
     }
-    switch (componentType) {
-      case BUTTON:
-        view.setAccessibilityDelegate(BUTTON_DELEGATE);
-        break;
-      case RADIOBUTTON_CHECKED:
-        view.setAccessibilityDelegate(RADIOBUTTON_CHECKED_DELEGATE);
-        break;
-      case RADIOBUTTON_UNCHECKED:
-        view.setAccessibilityDelegate(RADIOBUTTON_UNCHECKED_DELEGATE);
-        break;
-      default:
-        view.setAccessibilityDelegate(null);
-        break;
-    }
+
+    view.setAccessibilityDelegate(delegate);
   }
 
   public static void sendAccessibilityEvent(View view, int eventType) {
     view.sendAccessibilityEvent(eventType);
   }
-
 }
+
+class AccessibilityDelegate extends View.AccessibilityDelegate {
+  private static final int CHECKABLE = 1;
+  private static final int CHECKED = 2;
+  private static final int DISABLED = 4;
+
+  private String className = null;
+  private int flags = 0;
+
+  boolean setComponentType(String componentType) {
+    switch (componentType) {
+      case AccessibilityHelper.BUTTON:
+        className = Button.class.getName();
+        break;
+      case AccessibilityHelper.RADIOBUTTON:
+        className = RadioButton.class.getName();
+        setCheckable();
+        break;
+      case AccessibilityHelper.CHECKED:
+        setChecked();
+        break;
+      case AccessibilityHelper.DISABLED:
+        setDisabled();
+        break;
+      default:
+        return false;
+    }
+
+    return true;
+  }
+
+  private boolean getCheckable() {
+    return (flags & CHECKABLE) != 0;
+  }
+
+  private void setCheckable() {
+    flags |= CHECKABLE;
+  }
+
+  private boolean getChecked() {
+    return (flags & CHECKED) != 0;
+  }
+
+  private void setChecked() {
+    flags |= CHECKED;
+  }
+
+  private boolean getDisabled() {
+    return (flags & DISABLED) != 0;
+  }
+
+  private void setDisabled() {
+    flags |= DISABLED;
+  }
+
+  @Override
+  public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
+    super.onInitializeAccessibilityEvent(host, event);
+    event.setClassName(className);
+    event.setChecked(getChecked());
+    event.setEnabled(!getDisabled());
+  }
+
+  @Override
+  public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfo info) {
+    super.onInitializeAccessibilityNodeInfo(host, info);
+    info.setClassName(className);
+    info.setCheckable(getCheckable());
+    info.setChecked(getChecked());
+    info.setEnabled(!getDisabled());
+  }
+}
+

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityHelper.java
@@ -14,6 +14,8 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.Button;
 import android.widget.RadioButton;
+import android.widget.CheckBox;
+import android.widget.Switch;
 
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
@@ -26,6 +28,8 @@ import com.facebook.react.bridge.ReadableType;
 
   static final String BUTTON = "button";
   static final String RADIOBUTTON = "radiobutton";
+  static final String CHECKBOX = "checkbox";
+  static final String SWITCH = "switch";
   static final String CHECKED = "checked";
   static final String DISABLED = "disabled";
   static final String RADIOBUTTON_CHECKED = "radiobutton_checked";
@@ -85,6 +89,14 @@ class AccessibilityDelegate extends View.AccessibilityDelegate {
         break;
       case AccessibilityHelper.RADIOBUTTON:
         className = RadioButton.class.getName();
+        setCheckable();
+        break;
+      case AccessibilityHelper.CHECKBOX:
+        className = CheckBox.class.getName();
+        setCheckable();
+        break;
+      case AccessibilityHelper.SWITCH:
+        className = Switch.class.getName();
         setCheckable();
         break;
       case AccessibilityHelper.CHECKED:

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.view.View;
 
 import com.facebook.react.R;
+import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
@@ -107,7 +108,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   }
 
   @ReactProp(name = PROP_ACCESSIBILITY_COMPONENT_TYPE)
-  public void setAccessibilityComponentType(T view, String accessibilityComponentType) {
+  public void setAccessibilityComponentType(T view, Dynamic accessibilityComponentType) {
     AccessibilityHelper.updateAccessibilityComponentType(view, accessibilityComponentType);
   }
 

--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -91,10 +91,19 @@ Assign this property to a custom function which will be called when someone perf
 
 #### accessibilityComponentType (Android)
 
-In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component. For instances, we support ‘button’, ‘radiobutton_checked’ and ‘radiobutton_unchecked’ and so on.
+In some cases, we also want to alert the end user of the type of selected component (i.e., that it is a “button”). If we were using native buttons, this would work automatically. Since we are using javascript, we need to provide a bit more context for TalkBack. To do so, you must specify the ‘accessibilityComponentType’ property for any UI component.
+
+To use, set the `accessibilityComponentType` property to one of (or an array of) accessibility strings:
+
+* **button** Used when the element should be treated as a button.
+* **radiobutton** Used when the element should be treated as a radio button.
+* **checked**  Used when the element (e.g. radio button) is checked.
+* **disabled** Used when the control is not enabled and does not respond to user input.
+* **radiobutton_checked** (deprecated) Same as ["radiobutton", "checked"].
+* **radiobutton_unchecked** (deprecated) Same as "radiobutton" or ["radiobutton"].
 
 ```javascript
-<TouchableWithoutFeedback accessibilityComponentType=”button”
+<TouchableWithoutFeedback accessibilityComponentType="button"
   onPress={this._onPress}>
   <View style={styles.button}>
     <Text style={styles.buttonText}>Press me!</Text>

--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -96,7 +96,9 @@ In some cases, we also want to alert the end user of the type of selected compon
 To use, set the `accessibilityComponentType` property to one of (or an array of) accessibility strings:
 
 * **button** Used when the element should be treated as a button.
+* **checkbox** Used when the element should be treated as a check box.
 * **radiobutton** Used when the element should be treated as a radio button.
+* **switch** Used when the element should be treated as a switch.
 * **checked**  Used when the element (e.g. radio button) is checked.
 * **disabled** Used when the control is not enabled and does not respond to user input.
 * **radiobutton_checked** (deprecated) Same as ["radiobutton", "checked"].


### PR DESCRIPTION
## Motivation
Android `accessibilityComponentType` prop only supported 3 values: `button`, `radiobutton_checked` and `radiobutton_unchecked`. With this PR the prop can accept an array of strings. The following new values are supported:
* checkbox
* radiobutton
* switch
* disabled

Issue: https://github.com/facebook/react-native/issues/13740

## Test Plan
Tested with RNTester app.

## Code Review
@lelandrichardson @gpeal 