### PR TITLE
Remove ReactEditText.requestFocus hack

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -64,9 +64,6 @@ public class ReactEditText extends EditText {
   // *TextChanged events should be triggered. This is less expensive than removing the text
   // listeners and adding them back again after the text change is completed.
   private boolean mIsSettingTextFromJS;
-  // This component is controlled, so we want it to get focused only when JS ask it to do so.
-  // Whenever android requests focus (which it does for random reasons), it will be ignored.
-  private boolean mIsJSSettingFocus;
   private int mDefaultGravityHorizontal;
   private int mDefaultGravityVertical;
   private int mNativeEventCount;
@@ -100,7 +97,6 @@ public class ReactEditText extends EditText {
     mNativeEventCount = 0;
     mMostRecentEventCount = 0;
     mIsSettingTextFromJS = false;
-    mIsJSSettingFocus = false;
     mBlurOnSubmit = true;
     mDisableFullscreen = false;
     mListeners = null;
@@ -195,9 +191,6 @@ public class ReactEditText extends EditText {
     // such as text selection.
     if (isFocused()) {
       return true;
-    }
-    if (!mIsJSSettingFocus) {
-      return false;
     }
     setFocusableInTouchMode(true);
     boolean focused = super.requestFocus(direction, previouslyFocusedRect);
@@ -323,9 +316,7 @@ public class ReactEditText extends EditText {
 
   // VisibleForTesting from {@link TextInputEventsTestCase}.
   public void requestFocusFromJS() {
-    mIsJSSettingFocus = true;
     requestFocus();
-    mIsJSSettingFocus = false;
   }
 
   /* package */ void clearFocusFromJS() {


### PR DESCRIPTION
## Motivation
ReactEditText contains a hack to prevent focus from being set from native code. Here are the comments in code:

```
  // This component is controlled, so we want it to get focused only when JS ask it to do so.
  // Whenever android requests focus (which it does for random reasons), it will be ignored.
```

Unfortunately one of the random reasons is when TalkBack is turned on and user wants to focus on a TextInput with double tap. With this hack the TextInput can never be focused on Android 6.0.

## Issues
https://github.com/facebook/react-native/issues/12205
https://github.com/facebook/react-native/issues/17042

## Test Plan
Tested with RNTester app. Doesn't seem to affect TextInput when TalkBack is off.

## Code Review
@gpeal @lelandrichardson @backwardok