### PR TITLE
Validate accessibilityComponentType data type

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityHelper.java
@@ -54,7 +54,7 @@ import com.facebook.react.bridge.ReadableType;
           };
           break;
       }
-    } else {
+    } else if (dynamic.getType() == ReadableType.Array) {
       ReadableArray componentTypeArray = dynamic.asArray();
 
       for (int i = 0; i < componentTypeArray.size(); i++) {
@@ -64,6 +64,8 @@ import com.facebook.react.bridge.ReadableType;
           break;
         };
       }
+    } else {
+      delegate = null;
     }
 
     view.setAccessibilityDelegate(delegate);


### PR DESCRIPTION
## Motivation
AccessibilityHelper can crash if it receives invalid data for `accessibilityComponentType` prop, even though the propType definition restricts it to string or array of strings.

## Test Plan
Tested with RNTester and didn't notice anything.

## Code Review
@gpeal 