### PR TITLE
Fix accessibilityComponentType crash

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
@@ -11,13 +11,18 @@ package com.facebook.react.bridge;
 
 import javax.annotation.Nullable;
 
-import android.support.v4.util.Pools;
+import android.support.v4.util.Pools.SimplePool;
 
 /**
  * Implementation of Dynamic wrapping a ReadableMap.
  */
 public class DynamicFromMap implements Dynamic {
-  private static final Pools.SimplePool<DynamicFromMap> sPool = new Pools.SimplePool<>(10);
+  private static final ThreadLocal<SimplePool<DynamicFromMap>> sPool = new ThreadLocal<SimplePool<DynamicFromMap>>() {
+    @Override
+    protected SimplePool<DynamicFromMap> initialValue() {
+      return new SimplePool<>(10);
+    }
+  };
 
   private @Nullable ReadableMap mMap;
   private @Nullable String mName;
@@ -26,7 +31,7 @@ public class DynamicFromMap implements Dynamic {
   private DynamicFromMap() {}
 
   public static DynamicFromMap create(ReadableMap map, String name) {
-    DynamicFromMap dynamic = sPool.acquire();
+    DynamicFromMap dynamic = sPool.get().acquire();
     if (dynamic == null) {
       dynamic = new DynamicFromMap();
     }
@@ -39,7 +44,7 @@ public class DynamicFromMap implements Dynamic {
   public void recycle() {
     mMap = null;
     mName = null;
-    sPool.release(this);
+    sPool.get().release(this);
   }
 
   @Override


### PR DESCRIPTION
## Motivation
`DynamicFromMap` internally uses `SimplePool` object to recycle dynamic prop objects. But the pool is not multi-thread safe. Before `accessibilityComponentType` prop was added, the only dynamic props are size props such as `left`, `paddingVertical`, `marginTop` and so on. These props are only accessed from the layout thread so the pool works fine. The new `accessibilityComponentType` prop is accessed from UI thread, so now two threads can access the pool object and caused random errors. This PR make the pool object thread local to avoid synchronization. After this change there are two pool objects created in the process.

## Test Plan 
Tested RNTester app and didn't notice anything.

## Code Review
@lelandrichardson @gpeal 
