### PR TITLE
Revert "Fix VO reading order (#45)"

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -145,21 +145,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   return RCTRecursiveAccessibilityLabel(self);
 }
 
--(NSInteger)accessibilityElementCount
-{
-  return self.subviews.count;
-}
-
--(id)accessibilityElementAtIndex:(NSInteger)index
-{
-  return [self.subviews objectAtIndex:index];
-}
-
--(NSInteger)indexOfAccessibilityElement:(id)element
-{
-  return [self.subviews indexOfObject:element];
-}
-
 - (void)setPointerEvents:(RCTPointerEvents)pointerEvents
 {
   _pointerEvents = pointerEvents;


### PR DESCRIPTION
## Summary

This reverts PR https://github.com/airbnb/react-native/pull/45. The previous PR fixed reading order on iOS, but also affected components such as TextInput and slowed down accessibility element enumeration. I can make it not affect other components, but that would require subclassing RCTView and create another component class for `<View>`. I'm going to revert this change and workaround the issue in js code instead.

## Code review
@gpeal 